### PR TITLE
GRIF-17 add get-components-contain-component service operation

### DIFF
--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -59,6 +59,27 @@ def get_product_contain_component(ctx, component_name, purl):
 
 
 @queries_grp.command(
+    name="get-components-contain-component",
+    help="List components contain component.",
+)
+@click.option("--name", "component_name")
+@click.option("--purl")
+@click.pass_context
+@progress_bar
+def get_component_contain_component(ctx, component_name, purl):
+    """List components that contain component."""
+    if not purl and not component_name:
+        click.echo(ctx.get_help())
+        exit(0)
+    if component_name:
+        q = core_queries.components_containing_component_query()
+        cprint(q.execute({"component_name": component_name}))
+    if purl:
+        q = core_queries.components_containing_specific_component_query()
+        cprint(q.execute({"purl": purl}))
+
+
+@queries_grp.command(
     name="get-product",
     help="Get Product Stream summary.",
 )

--- a/griffon/services/core_queries.py
+++ b/griffon/services/core_queries.py
@@ -70,6 +70,29 @@ class products_containing_specific_component_query:
         }
 
 
+class components_containing_specific_component_query:
+    """What components contain a specific component?"""
+
+    name = "components_containing_specific_component_query"
+    description = "What components contain a specific component?"
+    params = ["purl"]
+
+    def __init__(self) -> None:
+        self.corgi_session = CorgiService.create_session()
+
+    def execute(self, ctx) -> dict:
+        purl = ctx["purl"]
+        c = self.corgi_session.components.retrieve_list(
+            purl=purl,
+        )
+        return {
+            "link": c["link"],
+            "name": c["name"],
+            "purl": c["purl"],
+            "sources": c["sources"],
+        }
+
+
 class products_containing_component_query:
     """What products contain a component?"""
 
@@ -95,6 +118,38 @@ class products_containing_component_query:
                     "name": c.name,
                     "component_link": c["component_link"],
                     "component_purl": c["component_purl"],
+                }
+            )
+        return results
+
+
+class components_containing_component_query:
+    """What components contain a component?"""
+
+    name = "components_containing_component_query"
+    description = "What components contain a component?"
+    params = ["name"]
+
+    def __init__(self) -> None:
+        self.corgi_session = CorgiService.create_session()
+
+    def execute(self, ctx) -> dict:
+        component_name = ctx["component_name"]
+        # TODO: narrow down with includes_fields when it emerges in corgi bindings
+        components = self.corgi_session.components.retrieve_list(
+            name=component_name, namespace="REDHAT"
+        )
+        results = []
+        for c in components.results:
+            sources = []
+            for source in c.sources:
+                sources.append({"link": source["link"], "purl": source["purl"]})
+            results.append(
+                {
+                    "link": c.link,
+                    "name": c.name,
+                    "purl": c.purl,
+                    "sources": sources,
                 }
             )
         return results


### PR DESCRIPTION
Return all components that depend on a specific component
```
> griffon service queries get-components-contain-component --purl "pkg:rpm/nmap@7.70"
```
returns

```
{
  "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Arpm/nmap%407.70",
  "name": "nmap",
  "purl": "pkg:rpm/nmap@7.70",
  "sources": [
    {
      "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Arpm/redhat/libabigail%402.1-2.el9%3Farch%3Dsrc",
      "purl": "pkg:rpm/redhat/libabigail@2.1-2.el9?arch=src"
    },
    {
      "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Arpm/redhat/libabigail%402.1-1.el9%3Farch%3Dsrc",
      "purl": "pkg:rpm/redhat/libabigail@2.1-1.el9?arch=src"
    }
  ]
}
```

similarly, to return components by specifying just a name

```
> griffon service queries get-components-contain-component --name nmap | jq ".results[].sources[]"
```

which would provide a flat list of components that use all versions of nmap (eg. just the name).
