### PR TITLE
add --type filter

### DIFF
--- a/griffon/commands/entities.py
+++ b/griffon/commands/entities.py
@@ -224,7 +224,6 @@ def components(ctx):
     "--arch",
     type=click.Choice(CorgiService.get_component_arches()),
 )
-@click.option("--view", default="summary")
 @click.pass_context
 @progress_bar
 def list_components(
@@ -238,7 +237,6 @@ def list_components(
     version,
     component_type,
     arch,
-    view,
 ):
     """Retrieve a list of components."""
 
@@ -257,7 +255,8 @@ def list_components(
     session = CorgiService.create_session()
 
     conditions = default_conditions
-    conditions["view"] = view
+    # conditions["view"] = view
+    conditions["include_fields"] = "link,purl,type,name"
 
     # TODO- condition union could be a separate helper function
 
@@ -275,6 +274,8 @@ def list_components(
         conditions["version"] = version
     if arch:
         conditions["arch"] = arch
+    if component_type:
+        conditions["type"] = component_type
 
     # TODO- This kind of optimisation should probably be developed in the
     #       service binding itself rather then here

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from griffon import OSIDBService, progress_bar
+from griffon import CorgiService, OSIDBService, progress_bar
 from griffon.autocomplete import get_cve_ids, get_product_version_names
 from griffon.commands.entities import (
     get_component_manifest,
@@ -64,19 +64,33 @@ def get_product_contain_component(ctx, component_name, purl):
 )
 @click.option("--name", "component_name")
 @click.option("--purl")
+@click.option("--type", "component_type", type=click.Choice(CorgiService.get_component_types()))
 @click.pass_context
 @progress_bar
-def get_component_contain_component(ctx, component_name, purl):
+def get_component_contain_component(ctx, component_name, purl, component_type):
     """List components that contain component."""
     if not purl and not component_name:
         click.echo(ctx.get_help())
         exit(0)
     if component_name:
         q = core_queries.components_containing_component_query()
-        cprint(q.execute({"component_name": component_name}), ctx=ctx)
+        cprint(
+            q.execute(
+                {
+                    "component_name": component_name,
+                    "component_type": component_type,
+                }
+            ),
+            ctx=ctx,
+        )
     if purl:
         q = core_queries.components_containing_specific_component_query()
-        cprint(q.execute({"purl": purl}), ctx=ctx)
+        cprint(
+            q.execute(
+                {"purl": purl, "component_type": component_type},
+            ),
+            ctx=ctx,
+        )
 
 
 @queries_grp.command(
@@ -305,9 +319,6 @@ def cves_for_specific_product_query(
         ),
         ctx=ctx,
     )
-
-
-# cves_for_product_stream_query
 
 
 @core_grp.command(


### PR DESCRIPTION
Filter latest components for **ansible_automation_platform-2.2** by RPM type
```
>  griffon entities components list --ofuri o:redhat:ansible_automation_platform:2.2 --type RPM
```
to retrieve just its containers
```
> griffon entities components list --ofuri o:redhat:ansible_automation_platform:2.2 --type OCI
```
Filter returned sources by type
```
> griffon service queries get-components-contain-component --name nmap --type RPM
```
Similarly we can filter a single component's sources by type
```
> griffon service queries get-components-contain-component --purl "pkg:rpm/redhat/libarchive@3.3.3-3.el8_5?arch=aarch64" --type OCI
```

```
> griffon service queries get-components-contain-component --purl "pkg:rpm/redhat/libarchive@3.3.3-3.el8_5?arch=aarch64" --type RPM
```