### PR TITLE
GRIF-30, add ~/.griffonrc file

### DIFF
--- a/griffon/__init__.py
+++ b/griffon/__init__.py
@@ -1,5 +1,7 @@
+import configparser
 import logging
 import os
+from configparser import ConfigParser
 from functools import partial, wraps
 
 import corgi_bindings
@@ -13,6 +15,9 @@ __version__ = "0.1.0"
 CORGI_API_URL = os.environ["CORGI_API_URL"]
 OSIDB_API_URL = os.environ["OSIDB_API_URL"]
 
+GRIFFON_CONFIG_DIR = os.getenv("GRIFFON_API_URL", "~/.griffon")
+GRIFFON_RC_FILE = "~/.griffonrc"
+
 logger = logging.getLogger("rich")
 
 
@@ -20,6 +25,20 @@ def get_logging(level="INFO"):
     FORMAT = "%(message)s"
     logging.basicConfig(level=level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
     return logging.getLogger("rich")
+
+
+def get_config():
+    """read ~/.griffonrc ini file, if it does not exist then return some default config"""
+    if not os.path.exists(os.path.expanduser(GRIFFON_RC_FILE)):
+        config = configparser.ConfigParser(allow_no_value=True)
+        config.optionxform = str
+        config.add_section("default")
+        config["default"]["format"] = "text"
+        config.add_section("exclude")
+        return config
+    config = ConfigParser()
+    config.read(os.path.expanduser(GRIFFON_RC_FILE))
+    return config
 
 
 class CorgiService:

--- a/griffon/cli.py
+++ b/griffon/cli.py
@@ -6,7 +6,7 @@ import logging
 import click
 import click_completion
 
-from griffon import get_logging
+from griffon import get_config, get_logging
 
 from .commands.configure import configure_grp
 from .commands.docs import docs_grp
@@ -21,6 +21,8 @@ from .output import OUTPUT_FORMAT
 logger = logging.getLogger("rich")
 
 click_completion.init()
+
+griffon_config = get_config()
 
 
 @click.group()
@@ -90,7 +92,7 @@ docs.add_command(docs_grp)
 @click.option(
     "--format",
     type=click.Choice([el.value for el in OUTPUT_FORMAT]),
-    default="json",
+    default=griffon_config["default"]["format"],
 )
 @click.pass_context
 def cli(ctx, debug, format):

--- a/griffon/commands/configure.py
+++ b/griffon/commands/configure.py
@@ -1,9 +1,13 @@
 """
 
 """
+import configparser
 import logging
+import os
 
 import click
+
+from griffon import GRIFFON_CONFIG_DIR, GRIFFON_RC_FILE
 
 logger = logging.getLogger("rich")
 
@@ -15,7 +19,19 @@ def configure_grp(ctx):
     pass
 
 
-@configure_grp.command(name="stub")
-def stub():
+@configure_grp.command(name="setup", help="Create ~/.griffon and .griffonrc config file")
+def setup():
     """stub"""
-    click.echo("generate ~/.griffonrc configuration file")
+    if not os.path.exists(os.path.expanduser(GRIFFON_CONFIG_DIR)):
+        os.makedirs(os.path.expanduser(GRIFFON_CONFIG_DIR))
+        logger.warning(f"{GRIFFON_CONFIG_DIR} created")
+    else:
+        logger.warning(f"{GRIFFON_CONFIG_DIR} already exists")
+
+    config = configparser.ConfigParser(allow_no_value=True)
+    config.optionxform = str
+    config.add_section("default")
+    config["default"]["format"] = "text"
+    config.add_section("exclude")
+    with open(os.path.expanduser(GRIFFON_RC_FILE), "w") as configfile:
+        config.write(configfile)


### PR DESCRIPTION
to initialise _~/.griffonrc_ and _~/.griffon/_

```
> griffon configure setup
```
which will create a ini dotfile at default location _~/.griffonrc_

following the normal ini file format 
```
[default]
format = text
[exclude]
```


