### PR TITLE
Minor: fix --no-color flag

### DIFF
--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -158,6 +158,7 @@ def get_product_manifest_query(ctx, ofuri, product_stream_name):
 @click.option(
     "--name", "product_stream_name", type=click.STRING, shell_complete=get_product_stream_names
 )
+@click.pass_context
 def get_product_latest_components_query(ctx, ofuri, product_stream_name):
     """List components of a specific product version."""
     if not ofuri and not product_stream_name:
@@ -182,6 +183,7 @@ def get_product_latest_components_query(ctx, ofuri, product_stream_name):
 @click.option(
     "--name", "product_stream_name", type=click.STRING, shell_complete=get_product_stream_names
 )
+@click.pass_context
 def get_product_all_components_query(ctx, ofuri, product_stream_name):
     """List components of a specific product stream."""
     if not ofuri and not product_stream_name:

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -90,7 +90,7 @@ def cprint(
     """handle format and output"""
     output = raw_json_transform(data, show_count)
     console = Console(color_system="auto")
-    if ctx and "NO_COLOR" in ctx.obj:
+    if ctx.obj and ctx.obj["NO_COLOR"]:
         console = Console(color_system=None)
     format = OUTPUT_FORMAT.JSON
     if ctx and "FORMAT" in ctx.obj:


### PR DESCRIPTION
inadvertently broke color formatting when implementing --no-color flag ... bringing it back. 

added back needed @click.passthru