### PR TITLE
add re-name to products-contain-component, components-contain-component

### DIFF
--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -39,6 +39,7 @@ queries_grp.add_command(generate_affects_for_component_process)
     name="products-contain-component",
     help="List Products containing Component.",
 )
+@click.option("--re-name", "component_re_name", help="Search name by regex.")
 @click.option("--name", "component_name")
 @click.option("--purl")
 @click.option(
@@ -53,14 +54,16 @@ queries_grp.add_command(generate_affects_for_component_process)
 @click.option("--type", "component_type", type=click.Choice(CorgiService.get_component_types()))
 @click.pass_context
 @progress_bar
-def get_product_contain_component(ctx, component_name, purl, arch, namespace, component_type):
+def get_product_contain_component(
+    ctx, component_re_name, component_name, purl, arch, namespace, component_type
+):
     """List components of a product version."""
-    if not purl and not component_name:
+    if not purl and not component_name and not component_re_name:
         click.echo(ctx.get_help())
         click.echo("")
         click.echo("Must supply --name or --purl.")
         exit(0)
-    if component_name:
+    if component_name or component_re_name:
         q = query_service.invoke(core_queries.products_containing_component_query, ctx.params)
         cprint(q, ctx=ctx)
     if purl:
@@ -74,18 +77,21 @@ def get_product_contain_component(ctx, component_name, purl, arch, namespace, co
     name="components-contain-component",
     help="List Components contain component.",
 )
+@click.option("--re-name", "component_re_name", help="Search name by regex.")
 @click.option("--name", "component_name")
 @click.option("--purl")
 @click.option("--type", "component_type", type=click.Choice(CorgiService.get_component_types()))
 @click.option("--namespace", type=click.Choice(CorgiService.get_component_namespaces()))
 @click.pass_context
 @progress_bar
-def get_component_contain_component(ctx, component_name, purl, component_type, namespace):
+def get_component_contain_component(
+    ctx, component_re_name, component_name, purl, component_type, namespace
+):
     """List components that contain component."""
-    if not purl and not component_name:
+    if not purl and not component_name and not component_re_name:
         click.echo(ctx.get_help())
         exit(0)
-    if component_name:
+    if component_name or component_re_name:
         q = query_service.invoke(core_queries.components_containing_component_query, ctx.params)
         cprint(
             q,
@@ -114,13 +120,19 @@ def get_component_contain_component(ctx, component_name, purl, component_type, n
     help="UNDER DEVELOPMENT",
 )
 @click.option(
+    "--re-name",
+    "product_stream_re_name",
+    type=click.STRING,
+    shell_complete=get_product_stream_names,
+)
+@click.option(
     "--name", "product_stream_name", type=click.STRING, shell_complete=get_product_stream_names
 )
 @click.pass_context
 @progress_bar
-def get_product_query(ctx, inactive, ofuri, product_stream_name):
+def get_product_query(ctx, inactive, ofuri, product_stream_re_name, product_stream_name):
     """get product stream."""
-    if not product_stream_name and not ofuri:
+    if not product_stream_name and not ofuri or not product_stream_re_name:
         click.echo(ctx.get_help())
         exit(0)
     q = query_service.invoke(core_queries.product_stream_summary, ctx.params)
@@ -305,6 +317,12 @@ def cves_for_specific_component_query(ctx, purl, affectedness):
     help="(UNDER DEV) List Flaws affecting a Product.",
 )
 @click.option(
+    "--re-name",
+    "product_version_re_name",
+    help="product_version name (eg. ps_module)",
+    shell_complete=get_product_version_names,
+)
+@click.option(
     "--name",
     "product_version_name",
     help="product_version name (eg. ps_module)",
@@ -318,6 +336,7 @@ def cves_for_specific_component_query(ctx, purl, affectedness):
 @click.pass_context
 def cves_for_specific_product_query(
     ctx,
+    product_version_re_name,
     product_version_name,
     affectedness,
     affect_impact,

--- a/griffon/services/core_queries.py
+++ b/griffon/services/core_queries.py
@@ -56,7 +56,14 @@ class products_containing_specific_component_query:
 
     name = "products_containing_specific_component_query"
     description = "What products contain a specific component?"
-    allowed_params = ["component_name", "purl", "arch", "namespace", "component_type"]
+    allowed_params = [
+        "component_re_name",
+        "component_name",
+        "purl",
+        "arch",
+        "namespace",
+        "component_type",
+    ]
 
     def __init__(self, params: dict) -> None:
         self.corgi_session = CorgiService.create_session()
@@ -75,7 +82,14 @@ class products_containing_component_query:
 
     name = "products_containing_component_query"
     description = "What products contain a component?"
-    allowed_params = ["component_name", "purl", "arch", "namespace", "component_type"]
+    allowed_params = [
+        "component_re_name",
+        "component_name",
+        "purl",
+        "arch",
+        "namespace",
+        "component_type",
+    ]
 
     def __init__(self, params: dict) -> None:
         self.corgi_session = CorgiService.create_session()
@@ -83,14 +97,19 @@ class products_containing_component_query:
 
     def execute(self) -> List[Dict[str, Any]]:
         component_name = self.params["component_name"]
+        component_re_name = self.params["component_re_name"]
         component_type = self.params["component_type"]
         ns = self.params["namespace"]
         cond = {}
-        cond["name"] = component_name
+        if component_re_name:
+            cond["re_name"] = component_re_name
+        else:
+            cond["name"] = component_name
         if component_type:
             cond["type"] = component_type
         if ns == "REDHAT":
             cond["namespace"] = "REDHAT"
+
         components: List[Any] = []
         logger.debug("starting parallel http requests")
         component_cnt = self.corgi_session.components.retrieve_list(**cond).count
@@ -141,7 +160,7 @@ class product_stream_summary:
 
     name = "product_stream_summary"
     description = "retrieve product_stream summary"
-    allowed_params = ["product_stream_name", "ofuri", "inactive"]
+    allowed_params = ["product_stream_re_name", "product_stream_name", "ofuri", "inactive"]
 
     def __init__(self, params: dict) -> None:
         self.corgi_session = CorgiService.create_session()
@@ -181,7 +200,7 @@ class components_containing_specific_component_query:
 
     name = "components_containing_specific_component_query"
     description = "What components contain a specific component?"
-    allowed_params = ["component_name", "purl", "component_type", "namespace"]
+    allowed_params = ["component_re_name", "component_name", "purl", "component_type", "namespace"]
 
     def __init__(self, params: dict):
         self.corgi_session = CorgiService.create_session()
@@ -211,7 +230,7 @@ class components_containing_component_query:
 
     name = "components_containing_component_query"
     description = "What components contain a component?"
-    allowed_params = ["component_name", "purl", "component_type", "namespace"]
+    allowed_params = ["component_re_name", "component_name", "purl", "component_type", "namespace"]
 
     def __init__(self, params: dict) -> None:
         self.corgi_session = CorgiService.create_session()
@@ -220,10 +239,15 @@ class components_containing_component_query:
     def execute(self) -> List[Dict[str, Any]]:
         component_type = self.params["component_type"]
         component_name = self.params["component_name"]
+        component_re_name = self.params["component_re_name"]
         namespace = self.params["namespace"]
 
         cond = {}
-        cond["name"] = component_name
+        if component_re_name:
+            cond["re_name"] = component_re_name
+        else:
+            cond["name"] = component_name
+
         if namespace:
             cond["namespace"] = namespace
 
@@ -427,6 +451,7 @@ class cves_for_specific_product_query:
     name = "cves-for-product"
     description = "What cves affect a specific product ?"
     allowed_params = [
+        "product_version_re_name",
         "product_version_name",
         "affectedness",
         "affect_resolution",


### PR DESCRIPTION
So we can invoke operations with regex search on name, for example

```
griffon service components-contain-component --re-name "^webkitgtk(\d)?$" | awk '{print $1}' | uniq
```