### PR TITLE
Fix OSIDB bindings usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,44 @@
-Changelog
 All notable changes to this project will be documented in this file.
 
-This project is kept in version sync with the Component Registry project, see the version policy and thus a lot of versions don't bring ground breaking changes and they rather update the API endpoints. In such cases the version is listed without any additions/changes/deletions.
+This project is kept in version sync with the OSIDB project, see the
+[version policy](TUTORIAL.md#osidb-compatibility) and thus a lot of
+versions don't bring ground breaking changes and they rather update
+the API endpoints. In such cases the version is listed without and
+addition/changes/deletion.
 
-The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[0.1.5] - 2023-03-23
-Fixed
-fixed --search-all when it encounters a Bad Gateway
-Added
-added --all to service product-summary to return all products
+## Unreleased
+### Changed
+- fix imports of Flaw/Affect resolution from osidb-bindings
 
-[0.1.4] - 2023-03-21
-Fixed
-fixed logging which was emitting double statements
-Fixed
-handling short version name processing on empty version
+## [0.1.5] - 2023-03-23
+### Added
+- added --all to service product-summary to return all products
 
-[0.1.3] - 2023-03-20
-Added
-refactored profiles (changed 'all' to match 'default' section) and added verbosity and default setting in .griffonrc
-Added
-minor text output formatting (shortern sha256 version names)
-Added
-new draft tutorial
+### Changed
+- fixed --search-all when it encounters a Bad Gateway
 
-[0.1.2] - 2023-03-17
-Fixed
-use pkg_resources to access static resources
+## [0.1.4] - 2023-03-21
+### Changed
+- fixed logging which was emitting double statements
+- handling short version name processing on empty version
 
-[0.1.1] - 2023-03-17
-Fixed
-changed .griffonrc file path to the correct path
+## [0.1.3] - 2023-03-20
+### Added
+- refactored profiles (changed 'all' to match 'default' section) and added verbosity and default setting in .griffonrc
+- minor text output formatting (shortern sha256 version names)
+- new draft tutorial
 
-[0.1.0] - 2023-03-17
-Added
-Initial official release to the PyPI
+## [0.1.2] - 2023-03-17
+### Changed
+- use pkg_resources to access static resources
+
+## [0.1.1] - 2023-03-17
+### Changed
+- changed .griffonrc file path to the correct path
+
+## [0.1.0] - 2023-03-17
+### Added
+- Initial official release to the PyPI

--- a/griffon/__init__.py
+++ b/griffon/__init__.py
@@ -137,7 +137,14 @@ class OSIDBService:
     @staticmethod
     def get_flaw_resolutions():
         """get flaw resolution enum"""
-        return osidb_bindings.bindings.python_client.models.FlawResolutionEnum
+        # TODO: FlawResolutionEnum changed to Resolution01FEnum in OSIDB schema
+        # due to some weird drf-spectacular naming clash resolution, there is
+        # a way ho to set this to a immutable name however this would require
+        # new OSIDB release, so importing the current path and once OSIDB schema
+        # is changed and released we can change it back to normal
+        #
+        # return osidb_bindings.bindings.python_client.models.FlawResolutionEnum
+        return osidb_bindings.bindings.python_client.models.Resolution01FEnum
 
     @staticmethod
     def get_flaw_impacts():
@@ -152,7 +159,14 @@ class OSIDBService:
     @staticmethod
     def get_affect_resolution():
         """get affect affectedness enum"""
-        return osidb_bindings.bindings.python_client.models.AffectResolutionEnum
+        # TODO: AffectResolutionEnum changed to Resolution3AcEnum in OSIDB schema
+        # due to some weird drf-spectacular naming clash resolution, there is
+        # a way ho to set this to a immutable name however this would require
+        # new OSIDB release, so importing the current path and once OSIDB schema
+        # is changed and released we can change it back to normal
+        #
+        # return osidb_bindings.bindings.python_client.models.AffectResolutionEnum
+        return osidb_bindings.bindings.python_client.models.Resolution3AcEnum
 
     @staticmethod
     def get_affect_impact():


### PR DESCRIPTION
`FlawResolutionEnum` and `AffectResolutionEnum` in osidb-bindings were changed to a kinda weird naming `Resolution01FEnum` and `Resolution3AcEnum`. This is due to a drf-spectacular which is responsible in schema creation in OSIDB to incorrectly resolve the naming clash.  We have a neat ways how to restrict these enums to not change the name in the future however this needs to be applied in OSIDB and thus another release is needed. Meanwhile we simply import new enums as a workaround.