### PR TITLE
Fix changelog description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
+# Changelog
 All notable changes to this project will be documented in this file.
-
-This project is kept in version sync with the OSIDB project, see the
-[version policy](TUTORIAL.md#osidb-compatibility) and thus a lot of
-versions don't bring ground breaking changes and they rather update
-the API endpoints. In such cases the version is listed without and
-addition/changes/deletion.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
Some additional lines were copied from osidb-bindings project during the changelog reformat, this PR removes them.