### PR TITLE
Refactor corgi entities

### DIFF
--- a/griffon/commands/entities/__init__.py
+++ b/griffon/commands/entities/__init__.py
@@ -1,0 +1,25 @@
+import logging
+
+import click
+
+from .component_registry import component_registry_grp
+from .osidb import osidb_grp
+
+logger = logging.getLogger("griffon")
+
+
+default_conditions: dict = {}
+
+
+@click.group(name="entities", help="Entity operations.")
+@click.option("--open-browser", is_flag=True, help="open browser to service results.")
+@click.option("--limit", default=10, help="# of items returned by list operations.")
+@click.pass_context
+def entities_grp(ctx, open_browser, limit):
+    ctx.ensure_object(dict)
+    ctx.obj["open_browser"] = open_browser
+    ctx.obj["limit"] = limit
+
+
+entities_grp.add_command(osidb_grp)
+entities_grp.add_command(component_registry_grp)

--- a/griffon/commands/entities/component_registry.py
+++ b/griffon/commands/entities/component_registry.py
@@ -1,0 +1,429 @@
+"""
+component-registry entity operations
+
+"""
+import concurrent.futures
+import logging
+
+import click
+
+from griffon import CORGI_API_URL, CorgiService, progress_bar
+from griffon.autocomplete import (
+    get_component_names,
+    get_component_purls,
+    get_product_stream_names,
+    get_product_stream_ofuris,
+)
+from griffon.output import console, cprint
+
+logger = logging.getLogger("griffon")
+
+default_conditions: dict = {}
+
+
+@click.group(name="CORGI")
+@click.pass_context
+def component_registry_grp(ctx):
+    pass
+
+
+@component_registry_grp.group(help=f"{CORGI_API_URL}/api/v1/components")
+@click.pass_context
+def components(ctx):
+    pass
+
+
+@components.command(name="list")
+@click.argument("component_name", required=False)
+@click.option("--namespace", type=click.Choice(CorgiService.get_component_namespaces()), help="")
+@click.option("--ofuri", shell_complete=get_product_stream_ofuris)
+@click.option("--re_purl", shell_complete=get_component_purls)
+@click.option("--re_name", shell_complete=get_component_names)
+@click.option("--version")
+@click.option(
+    "--type",
+    "component_type",
+    type=click.Choice(CorgiService.get_component_types()),
+    help="",  # noqa
+)
+@click.option(
+    "--arch",
+    type=click.Choice(CorgiService.get_component_arches()),
+)
+@click.option("--product-stream-name", shell_complete=get_product_stream_names)
+@click.option("--product-stream-ofuri", shell_complete=get_product_stream_ofuris)
+@click.pass_context
+@progress_bar
+def list_components(
+    ctx,
+    component_name,
+    namespace,
+    ofuri,
+    re_purl,
+    re_name,
+    version,
+    component_type,
+    arch,
+    product_stream_name,
+    product_stream_ofuri,
+):
+    """Retrieve a list of Components."""
+
+    if (
+        not component_name
+        and not ofuri
+        and not re_purl
+        and not re_name
+        and not version
+        and not arch
+        and not namespace
+        and not component_type
+        and not product_stream_name
+        and not product_stream_ofuri
+    ):
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+
+    conditions = default_conditions
+    conditions[
+        "include_fields"
+    ] = "link,purl,nvr,version,type,name,upstreams,related_url,download_url"
+
+    # TODO- condition union could be a separate helper function
+
+    if component_name:
+        conditions["name"] = component_name
+
+    if namespace:
+        conditions["namespace"] = namespace
+    if ofuri:
+        conditions["ofuri"] = ofuri
+    if re_purl:
+        conditions["re_purl"] = re_purl
+    if re_name:
+        conditions["re_name"] = re_name
+    if version:
+        conditions["version"] = version
+    if arch:
+        conditions["arch"] = arch
+    if component_type:
+        conditions["type"] = component_type
+    if product_stream_ofuri:
+        conditions["product_streams"] = product_stream_ofuri
+
+    # TODO- This kind of optimisation should probably be developed in the
+    #       service binding itself rather then here
+    logger.debug("starting parallel http requests")
+    component_cnt = session.components.retrieve_list(**conditions).count
+    if component_cnt < 3000000:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = []
+            components = list()
+            for batch in range(0, component_cnt, 1200):
+                futures.append(
+                    executor.submit(
+                        session.components.retrieve_list,
+                        **conditions,
+                        offset=batch,
+                        limit=1200,  # noqa
+                    )
+                )
+
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    components.extend(future.result().results)
+                except Exception as exc:
+                    logger.warning("%r generated an exception: %s" % (future, exc))
+
+            data = sorted(components, key=lambda d: d.purl)
+            return cprint(data, ctx=ctx)
+    else:
+        console.print("downloading too many")
+
+
+@components.command(name="get")
+@click.option("--uuid", "component_uuid")
+@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
+@click.option("--nvr")
+@click.pass_context
+@progress_bar
+def get_component(ctx, component_uuid, purl, nvr):
+    """Retrieve Component."""
+    if not component_uuid and not purl and not nvr:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    data = session.components.retrieve_list(purl=purl)
+    return cprint(data, ctx=ctx)
+
+
+@components.command(
+    name="summary",
+    help="Get Component summaries.",
+)
+@click.argument(
+    "component_name",
+    required=False,
+)
+@click.option(
+    "-s",
+    "strict_name_search",
+    is_flag=True,
+    default=False,
+    help="Strict search, exact match of name.",
+)
+@click.pass_context
+@progress_bar
+def get_component_summary(ctx, component_name, strict_name_search):
+    """Get Component summary."""
+    if not component_name:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+
+    cond = {
+        "include_fields": "name,type,download_url,purl,tags,arch,release,version,product_streams,upstreams,related_url",  # noqa
+        "name": component_name,
+    }
+    components = session.components.retrieve_list(**cond, limit=10000)
+    product_streams = []
+    upstreams = []
+    versions = []
+    releases = []
+    arches = []
+    related_urls = []
+    download_urls = []
+    tags = []
+    component_type = None
+    for component in components.results:
+        component_type = component.type
+        related_urls.append(component.related_url)
+        arches.append(component.arch)
+        versions.append(component.version)
+        releases.append(component.release)
+        tags.extend(component.tags)
+        for upstream in component.upstreams:
+            upstreams.append(upstream["purl"])
+        for ps in component.product_streams:
+            product_streams.append(ps["name"])
+
+    cond = {
+        "include_fields": "name,purl,version,type,tags,arch,release,product_streams",  # noqa
+        "name": component_name,
+        "view": "latest",
+    }
+    latest_components = session.components.retrieve_list(**cond, limit=10000)
+
+    latest = []
+
+    for latest_component in latest_components.results:
+        latest.append(
+            {
+                "product_stream": latest_component["product_stream"],
+                "purl": latest_component.purl,
+            }
+        )
+    data = {
+        "link": f"{CORGI_API_URL}/api/v1/components?name={component_name}",
+        "type": component_type,
+        "name": component_name,
+        "tags": sorted(list(set(tags))),
+        "count": len(components.results),
+        "product_streams": sorted(list(set(product_streams))),
+        "related_urls": sorted(list(set(related_urls))),
+        "download_urls": sorted(list(set(download_urls))),
+        "releases": sorted(list(set(releases))),
+        "upstreams": sorted(list(set(upstreams))),
+        "arches": sorted(list(set(arches))),
+        "versions": sorted(list(set(versions))),
+        "latest": latest,
+    }
+    cprint(data, ctx=ctx)
+
+
+@components.command(name="provides")
+@click.option("--uuid", "component_uuid")
+@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
+@click.pass_context
+@progress_bar
+def get_component_provides(ctx, component_uuid, purl):
+    """Retrieve all Components provided by a Component."""
+    if not component_uuid and not purl:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    if component_uuid:
+        data = session.components.retrieve(component_uuid).provides
+        return cprint(data, ctx=ctx)
+    else:
+        c = session.components.retrieve_list(purl=purl)
+        if c:
+            data = session.components.retrieve(c["uuid"]).provides
+            return cprint(data, ctx=ctx)
+
+
+@components.command(name="sources")
+@click.option("--uuid", "component_uuid")
+@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
+@click.pass_context
+@progress_bar
+def get_component_sources(ctx, component_uuid, purl):
+    """Retrieve all Components that contain Component."""
+    if not component_uuid and not purl:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    if component_uuid:
+        data = session.components.retrieve(component_uuid).sources
+        return cprint(data, ctx=ctx)
+    else:
+        c = session.components.retrieve_list(purl=purl)
+        if c:
+            data = session.components.retrieve(c["uuid"]).sources
+            return cprint(data, ctx=ctx)
+
+
+@components.command(name="manifest")
+@click.option("--uuid", "component_uuid")
+@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
+@click.pass_context
+@progress_bar
+def get_component_manifest(ctx, component_uuid, purl):
+    """Retrieve Component manifest."""
+    if not component_uuid and not purl:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    if component_uuid:
+        data = session.components.retrieve_manifest(component_uuid)
+        return cprint(data, ctx=ctx)
+    else:
+        c = session.components.retrieve_list(purl=purl)
+        if c:
+            data = session.components.retrieve_manifest(c["uuid"])
+            return cprint(data, ctx=ctx)
+
+
+# product streams
+@component_registry_grp.group(help=f"{CORGI_API_URL}/api/v1/product_streams")
+@click.pass_context
+def product_streams(ctx):
+    pass
+
+
+@product_streams.command(name="list")
+@click.argument(
+    "product_stream_name",
+    required=False,
+    type=click.STRING,
+    shell_complete=get_product_stream_names,
+)
+@click.pass_context
+def list_product_streams(ctx, product_stream_name):
+    """Retrieve a list of Product Streams."""
+    session = CorgiService.create_session()
+    cond = default_conditions
+    if product_stream_name:
+        cond["re_name"] = product_stream_name
+    data = session.product_streams.retrieve_list(**cond, limit=1000).results
+    return cprint(data, ctx=ctx)
+
+
+@product_streams.command(name="get")
+@click.argument(
+    "product_stream_name",
+    required=False,
+    type=click.STRING,
+    shell_complete=get_product_stream_names,
+)
+@click.option("--inactive", is_flag=True, default=False, help="Show inactive project streams")
+@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
+@click.pass_context
+@progress_bar
+def get_product_stream(ctx, product_stream_name, inactive, ofuri):
+    """Retrieve Product Stream."""
+    if not ofuri and not product_stream_name:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    cond = {}
+    if ofuri:
+        cond["ofuri"] = ofuri
+    if product_stream_name:
+        cond["name"] = product_stream_name
+    data = session.product_streams.retrieve_list(**cond)
+    return cprint(data, ctx=ctx)
+
+
+@product_streams.command(name="latest-components")
+@click.argument(
+    "product_stream_name",
+    required=False,
+    type=click.STRING,
+    shell_complete=get_product_stream_names,
+)
+@click.option("--namespace", type=click.Choice(CorgiService.get_component_namespaces()), help="")
+@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
+@click.option("--view", default="summary")
+@click.pass_context
+def get_product_stream_components(ctx, product_stream_name, namespace, ofuri, view):
+    """Retrieve Product Stream latest Components."""
+    if not ofuri and not product_stream_name:
+        click.echo(ctx.get_help())
+        exit(0)
+    ctx.invoke(list_components, ofuri=ofuri)
+
+
+@product_streams.command(name="manifest")
+@click.argument(
+    "product_stream_name",
+    required=False,
+    type=click.STRING,
+    shell_complete=get_product_stream_names,
+)
+@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
+@click.pass_context
+def get_product_stream_manifest(ctx, product_stream_name, ofuri):
+    """Retrieve Product Stream manifest."""
+    if not ofuri and not product_stream_name:
+        click.echo(ctx.get_help())
+        exit(0)
+    session = CorgiService.create_session()
+    pv = None
+    if ofuri:
+        pv = session.product_streams.retrieve_list(ofuri=ofuri).additional_properties
+    if product_stream_name:
+        pv = session.product_streams.retrieve_list(name=product_stream_name).additional_properties
+    if pv:
+        data = session.product_streams.retrieve_manifest(pv["uuid"])
+        return cprint(data, ctx=ctx)
+
+
+@component_registry_grp.group(help=f"{CORGI_API_URL}/api/v1/builds")
+@click.pass_context
+def builds(ctx):
+    pass
+
+
+@builds.command(name="list")
+@click.argument("software_build_name", required=False)
+@click.pass_context
+def list_software_builds(ctx, software_build_name):
+    """Retrieve a list of Software Builds."""
+    session = CorgiService.create_session()
+    cond = default_conditions
+    if software_build_name:
+        cond["name"] = software_build_name
+    data = session.builds.retrieve_list(**cond, limit=1000).results
+    return cprint(data, ctx=ctx)
+
+
+@builds.command(name="get")
+@click.argument("build_id", required=False)
+@click.pass_context
+def get_software_builds(ctx, build_id):
+    """Retrieve Software Build."""
+    session = CorgiService.create_session()
+    data = session.builds.retrieve(build_id)
+    return cprint(data, ctx=ctx)

--- a/griffon/commands/entities/osidb.py
+++ b/griffon/commands/entities/osidb.py
@@ -1,8 +1,7 @@
 """
-entity operations
+osidb entity operations
 
 """
-import concurrent.futures
 import inspect
 import json
 import logging
@@ -29,20 +28,7 @@ from osidb_bindings.bindings.python_client.models import Affect, Flaw, Tracker
 from osidb_bindings.bindings.python_client.types import OSIDBModel
 from requests import HTTPError
 
-from griffon import (
-    CORGI_API_URL,
-    OSIDB_API_URL,
-    CorgiService,
-    OSIDBService,
-    get_config_option,
-    progress_bar,
-)
-from griffon.autocomplete import (
-    get_component_names,
-    get_component_purls,
-    get_product_stream_names,
-    get_product_stream_ofuris,
-)
+from griffon import OSIDB_API_URL, OSIDBService, get_config_option, progress_bar
 from griffon.output import console, cprint
 
 logger = logging.getLogger("griffon")
@@ -204,18 +190,14 @@ def request_body_options(
     return inner
 
 
-@click.group(name="entities", help="Entity operations (UNDER DEVELOPMENT).")
-@click.option("--open-browser", is_flag=True, help="open browser to service results.")
-@click.option("--limit", default=10, help="# of items returned by list operations.")
+@click.group(name="OSIDB")
 @click.pass_context
-def entities_grp(ctx, open_browser, limit):
-    ctx.ensure_object(dict)
-    ctx.obj["open_browser"] = open_browser
-    ctx.obj["limit"] = limit
+def osidb_grp(ctx):
+    pass
 
 
 # flaws
-@entities_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/flaws")
+@osidb_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/flaws")
 @click.pass_context
 def flaws(ctx):
     """OSIDB Flaws."""
@@ -375,7 +357,7 @@ def create_flaw(ctx, **params):
 
 
 # affects
-@entities_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/affects")
+@osidb_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/affects")
 @click.pass_context
 def affects(ctx):
     """OSIDB Affects."""
@@ -551,7 +533,7 @@ def delete_affect(ctx, affect_uuid, **params):
 
 
 # trackers
-@entities_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/trackers")
+@osidb_grp.group(help=f"{OSIDB_API_URL}/osidb/api/v1/trackers")
 @click.pass_context
 def trackers(ctx):
     """OSIDB Trackers."""
@@ -597,407 +579,4 @@ def get_tracker(ctx, tracker_uuid, **params):
 
     session = OSIDBService.create_session()
     data = session.trackers.retrieve(tracker_uuid, **params)
-    return cprint(data, ctx=ctx)
-
-
-# components
-@entities_grp.group(help=f"{CORGI_API_URL}/api/v1/components")
-@click.pass_context
-def components(ctx):
-    pass
-
-
-@components.command(name="list")
-@click.argument("component_name", required=False)
-@click.option("--namespace", type=click.Choice(CorgiService.get_component_namespaces()), help="")
-@click.option("--ofuri", shell_complete=get_product_stream_ofuris)
-@click.option("--re_purl", shell_complete=get_component_purls)
-@click.option("--re_name", shell_complete=get_component_names)
-@click.option("--version")
-@click.option(
-    "--type",
-    "component_type",
-    type=click.Choice(CorgiService.get_component_types()),
-    help="",  # noqa
-)
-@click.option(
-    "--arch",
-    type=click.Choice(CorgiService.get_component_arches()),
-)
-@click.option("--product-stream-name", shell_complete=get_product_stream_names)
-@click.option("--product-stream-ofuri", shell_complete=get_product_stream_ofuris)
-@click.pass_context
-@progress_bar
-def list_components(
-    ctx,
-    component_name,
-    namespace,
-    ofuri,
-    re_purl,
-    re_name,
-    version,
-    component_type,
-    arch,
-    product_stream_name,
-    product_stream_ofuri,
-):
-    """Retrieve a list of Components."""
-
-    if (
-        not component_name
-        and not ofuri
-        and not re_purl
-        and not re_name
-        and not version
-        and not arch
-        and not namespace
-        and not component_type
-        and not product_stream_name
-        and not product_stream_ofuri
-    ):
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-
-    conditions = default_conditions
-    conditions[
-        "include_fields"
-    ] = "link,purl,nvr,version,type,name,upstreams,related_url,download_url"
-
-    # TODO- condition union could be a separate helper function
-
-    if component_name:
-        conditions["name"] = component_name
-
-    if namespace:
-        conditions["namespace"] = namespace
-    if ofuri:
-        conditions["ofuri"] = ofuri
-    if re_purl:
-        conditions["re_purl"] = re_purl
-    if re_name:
-        conditions["re_name"] = re_name
-    if version:
-        conditions["version"] = version
-    if arch:
-        conditions["arch"] = arch
-    if component_type:
-        conditions["type"] = component_type
-    if product_stream_ofuri:
-        conditions["product_streams"] = product_stream_ofuri
-
-    # TODO- This kind of optimisation should probably be developed in the
-    #       service binding itself rather then here
-    logger.debug("starting parallel http requests")
-    component_cnt = session.components.retrieve_list(**conditions).count
-    if component_cnt < 3000000:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = []
-            components = list()
-            for batch in range(0, component_cnt, 1200):
-                futures.append(
-                    executor.submit(
-                        session.components.retrieve_list,
-                        **conditions,
-                        offset=batch,
-                        limit=1200,  # noqa
-                    )
-                )
-
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    components.extend(future.result().results)
-                except Exception as exc:
-                    logger.warning("%r generated an exception: %s" % (future, exc))
-
-            data = sorted(components, key=lambda d: d.purl)
-            return cprint(data, ctx=ctx)
-    else:
-        console.print("downloading too many")
-
-
-@components.command(name="get")
-@click.option("--uuid", "component_uuid")
-@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
-@click.option("--nvr")
-@click.pass_context
-@progress_bar
-def get_component(ctx, component_uuid, purl, nvr):
-    """Retrieve Component."""
-    if not component_uuid and not purl and not nvr:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    data = session.components.retrieve_list(purl=purl)
-    return cprint(data, ctx=ctx)
-
-
-@components.command(
-    name="summary",
-    help="Get Component summaries.",
-)
-@click.argument(
-    "component_name",
-    required=False,
-)
-@click.option(
-    "-s",
-    "strict_name_search",
-    is_flag=True,
-    default=False,
-    help="Strict search, exact match of name.",
-)
-@click.pass_context
-@progress_bar
-def get_component_summary(ctx, component_name, strict_name_search):
-    """Get Component summary."""
-    if not component_name:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-
-    cond = {
-        "include_fields": "name,type,download_url,purl,tags,arch,release,version,product_streams,upstreams,related_url",  # noqa
-        "name": component_name,
-    }
-    components = session.components.retrieve_list(**cond, limit=10000)
-    product_streams = []
-    upstreams = []
-    versions = []
-    releases = []
-    arches = []
-    related_urls = []
-    download_urls = []
-    tags = []
-    component_type = None
-    for component in components.results:
-        component_type = component.type
-        related_urls.append(component.related_url)
-        arches.append(component.arch)
-        versions.append(component.version)
-        releases.append(component.release)
-        tags.extend(component.tags)
-        for upstream in component.upstreams:
-            upstreams.append(upstream["purl"])
-        for ps in component.product_streams:
-            product_streams.append(ps["name"])
-
-    cond = {
-        "include_fields": "name,purl,version,type,tags,arch,release,product_streams",  # noqa
-        "name": component_name,
-        "view": "latest",
-    }
-    latest_components = session.components.retrieve_list(**cond, limit=10000)
-
-    latest = []
-
-    for latest_component in latest_components.results:
-        latest.append(
-            {
-                "product_stream": latest_component["product_stream"],
-                "purl": latest_component.purl,
-            }
-        )
-    data = {
-        "link": f"{CORGI_API_URL}/api/v1/components?name={component_name}",
-        "type": component_type,
-        "name": component_name,
-        "tags": sorted(list(set(tags))),
-        "count": len(components.results),
-        "product_streams": sorted(list(set(product_streams))),
-        "related_urls": sorted(list(set(related_urls))),
-        "download_urls": sorted(list(set(download_urls))),
-        "releases": sorted(list(set(releases))),
-        "upstreams": sorted(list(set(upstreams))),
-        "arches": sorted(list(set(arches))),
-        "versions": sorted(list(set(versions))),
-        "latest": latest,
-    }
-    cprint(data, ctx=ctx)
-
-
-@components.command(name="provides")
-@click.option("--uuid", "component_uuid")
-@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
-@click.pass_context
-@progress_bar
-def get_component_provides(ctx, component_uuid, purl):
-    """Retrieve all Components provided by a Component."""
-    if not component_uuid and not purl:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    if component_uuid:
-        data = session.components.retrieve(component_uuid).provides
-        return cprint(data, ctx=ctx)
-    else:
-        c = session.components.retrieve_list(purl=purl)
-        if c:
-            data = session.components.retrieve(c["uuid"]).provides
-            return cprint(data, ctx=ctx)
-
-
-@components.command(name="sources")
-@click.option("--uuid", "component_uuid")
-@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
-@click.pass_context
-@progress_bar
-def get_component_sources(ctx, component_uuid, purl):
-    """Retrieve all Components that contain Component."""
-    if not component_uuid and not purl:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    if component_uuid:
-        data = session.components.retrieve(component_uuid).sources
-        return cprint(data, ctx=ctx)
-    else:
-        c = session.components.retrieve_list(purl=purl)
-        if c:
-            data = session.components.retrieve(c["uuid"]).sources
-            return cprint(data, ctx=ctx)
-
-
-@components.command(name="manifest")
-@click.option("--uuid", "component_uuid")
-@click.option("--purl", shell_complete=get_component_purls, help="Purl are URI and must be quoted.")
-@click.pass_context
-@progress_bar
-def get_component_manifest(ctx, component_uuid, purl):
-    """Retrieve Component manifest."""
-    if not component_uuid and not purl:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    if component_uuid:
-        data = session.components.retrieve_manifest(component_uuid)
-        return cprint(data, ctx=ctx)
-    else:
-        c = session.components.retrieve_list(purl=purl)
-        if c:
-            data = session.components.retrieve_manifest(c["uuid"])
-            return cprint(data, ctx=ctx)
-
-
-# product streams
-@entities_grp.group(help=f"{CORGI_API_URL}/api/v1/product_streams")
-@click.pass_context
-def product_streams(ctx):
-    pass
-
-
-@product_streams.command(name="list")
-@click.argument(
-    "product_stream_name",
-    required=False,
-    type=click.STRING,
-    shell_complete=get_product_stream_names,
-)
-@click.pass_context
-def list_product_streams(ctx, product_stream_name):
-    """Retrieve a list of Product Streams."""
-    session = CorgiService.create_session()
-    cond = default_conditions
-    if product_stream_name:
-        cond["re_name"] = product_stream_name
-    data = session.product_streams.retrieve_list(**cond, limit=1000).results
-    return cprint(data, ctx=ctx)
-
-
-@product_streams.command(name="get")
-@click.argument(
-    "product_stream_name",
-    required=False,
-    type=click.STRING,
-    shell_complete=get_product_stream_names,
-)
-@click.option("--inactive", is_flag=True, default=False, help="Show inactive project streams")
-@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
-@click.pass_context
-@progress_bar
-def get_product_stream(ctx, product_stream_name, inactive, ofuri):
-    """Retrieve Product Stream."""
-    if not ofuri and not product_stream_name:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    cond = {}
-    if ofuri:
-        cond["ofuri"] = ofuri
-    if product_stream_name:
-        cond["name"] = product_stream_name
-    data = session.product_streams.retrieve_list(**cond)
-    return cprint(data, ctx=ctx)
-
-
-@product_streams.command(name="latest-components")
-@click.argument(
-    "product_stream_name",
-    required=False,
-    type=click.STRING,
-    shell_complete=get_product_stream_names,
-)
-@click.option("--namespace", type=click.Choice(CorgiService.get_component_namespaces()), help="")
-@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
-@click.option("--view", default="summary")
-@click.pass_context
-def get_product_stream_components(ctx, product_stream_name, namespace, ofuri, view):
-    """Retrieve Product Stream latest Components."""
-    if not ofuri and not product_stream_name:
-        click.echo(ctx.get_help())
-        exit(0)
-    ctx.invoke(list_components, ofuri=ofuri)
-
-
-@product_streams.command(name="manifest")
-@click.argument(
-    "product_stream_name",
-    required=False,
-    type=click.STRING,
-    shell_complete=get_product_stream_names,
-)
-@click.option("--ofuri", "ofuri", type=click.STRING, shell_complete=get_product_stream_ofuris)
-@click.pass_context
-def get_product_stream_manifest(ctx, product_stream_name, ofuri):
-    """Retrieve Product Stream manifest."""
-    if not ofuri and not product_stream_name:
-        click.echo(ctx.get_help())
-        exit(0)
-    session = CorgiService.create_session()
-    pv = None
-    if ofuri:
-        pv = session.product_streams.retrieve_list(ofuri=ofuri).additional_properties
-    if product_stream_name:
-        pv = session.product_streams.retrieve_list(name=product_stream_name).additional_properties
-    if pv:
-        data = session.product_streams.retrieve_manifest(pv["uuid"])
-        return cprint(data, ctx=ctx)
-
-
-@entities_grp.group(help=f"{CORGI_API_URL}/api/v1/builds")
-@click.pass_context
-def builds(ctx):
-    pass
-
-
-@builds.command(name="list")
-@click.argument("software_build_name", required=False)
-@click.pass_context
-def list_software_builds(ctx, software_build_name):
-    """Retrieve a list of Software Builds."""
-    session = CorgiService.create_session()
-    cond = default_conditions
-    if software_build_name:
-        cond["name"] = software_build_name
-    data = session.builds.retrieve_list(**cond, limit=1000).results
-    return cprint(data, ctx=ctx)
-
-
-@builds.command(name="get")
-@click.argument("build_id", required=False)
-@click.pass_context
-def get_software_builds(ctx, build_id):
-    """Retrieve Software Build."""
-    session = CorgiService.create_session()
-    data = session.builds.retrieve(build_id)
     return cprint(data, ctx=ctx)

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -12,7 +12,7 @@ from griffon.autocomplete import (
     get_cve_ids,
     get_product_version_names,
 )
-from griffon.commands.entities import (
+from griffon.commands.entities.component_registry import (
     get_component_manifest,
     get_component_summary,
     get_product_stream_manifest,

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 osidb-bindings==3.0.1
-component-registry-bindings==1.3.2
+component-registry-bindings==1.3.3
 click
 click-completion
 rich

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,9 +113,9 @@ click==8.1.3 \
 click-completion==0.5.2 \
     --hash=sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86
     # via -r requirements/base.in
-component-registry-bindings==1.3.2 \
-    --hash=sha256:7ecc1e7a6d4f20f8b1b021ef28d49525da3bc5324211dc1cc25c1a972029122d \
-    --hash=sha256:e3918bf72bc9573c5d8aa4307f5bf08360950e157954cfef272c7899bc6b4f07
+component-registry-bindings==1.3.3 \
+    --hash=sha256:51dc66d5e130838d6ba159eeac8ff5423dd47d8f029573c3c9ff293aba9736d3 \
+    --hash=sha256:b3ce61e2eb3a57836418cf1d720b8c94ea49393f0ac3132735743e39fa923469
     # via -r requirements/base.in
 decorator==5.1.1 \
     --hash=sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -214,9 +214,9 @@ click-completion==0.5.2 \
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-component-registry-bindings==1.3.2 \
-    --hash=sha256:7ecc1e7a6d4f20f8b1b021ef28d49525da3bc5324211dc1cc25c1a972029122d \
-    --hash=sha256:e3918bf72bc9573c5d8aa4307f5bf08360950e157954cfef272c7899bc6b4f07
+component-registry-bindings==1.3.3 \
+    --hash=sha256:51dc66d5e130838d6ba159eeac8ff5423dd47d8f029573c3c9ff293aba9736d3 \
+    --hash=sha256:b3ce61e2eb3a57836418cf1d720b8c94ea49393f0ac3132735743e39fa923469
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -123,9 +123,9 @@ click==8.1.3 \
 click-completion==0.5.2 \
     --hash=sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86
     # via -r requirements/base.txt
-component-registry-bindings==1.3.2 \
-    --hash=sha256:7ecc1e7a6d4f20f8b1b021ef28d49525da3bc5324211dc1cc25c1a972029122d \
-    --hash=sha256:e3918bf72bc9573c5d8aa4307f5bf08360950e157954cfef272c7899bc6b4f07
+component-registry-bindings==1.3.3 \
+    --hash=sha256:51dc66d5e130838d6ba159eeac8ff5423dd47d8f029573c3c9ff293aba9736d3 \
+    --hash=sha256:b3ce61e2eb3a57836418cf1d720b8c94ea49393f0ac3132735743e39fa923469
     # via -r requirements/base.txt
 coverage[toml]==7.2.0 \
     --hash=sha256:049806ae2df69468c130f04f0fab4212c46b34ba5590296281423bb1ae379df2 \

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=[
         "griffon",
         "griffon/commands",
+        "griffon/commands/entities",
         "griffon/commands/plugins",
         "griffon/services",
         "griffon/autocomplete",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,23 +8,35 @@ pytestmark = pytest.mark.unit
 
 def test_cli_flaws():
     runner = CliRunner()
-    result = runner.invoke(cli, ["entities", "flaws"])
+    result = runner.invoke(cli, ["entities", "OSIDB", "flaws"])
     assert result.exit_code == 0
 
 
 def test_cli_affects():
     runner = CliRunner()
-    result = runner.invoke(cli, ["entities", "affects"])
+    result = runner.invoke(cli, ["entities", "OSIDB", "affects"])
     assert result.exit_code == 0
 
 
 def test_cli_trackers():
     runner = CliRunner()
-    result = runner.invoke(cli, ["entities", "trackers"])
+    result = runner.invoke(cli, ["entities", "OSIDB", "trackers"])
     assert result.exit_code == 0
 
 
 def test_cli_components():
     runner = CliRunner()
-    result = runner.invoke(cli, ["entities", "components"])
+    result = runner.invoke(cli, ["entities", "CORGI", "components"])
+    assert result.exit_code == 0
+
+
+def test_cli_builds():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["entities", "CORGI", "builds"])
+    assert result.exit_code == 0
+
+
+def test_cli_product_streams():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["entities", "CORGI", "product-streams"])
     assert result.exit_code == 0


### PR DESCRIPTION
refactored entrypoints to entities

> griffon entities OSIDB
> griffon entities CORGI

which makes it easy to create a shell alias, for example;

```
osidb-cli="griffon entities OSIDB"
```
