### PR TITLE
Add missing fields to license report and fix incorrect field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactored low level entities with nested entrypoint
 - moved manage to entities
 - expose more flags on product-components
+- add license_concluded to license report when available
+- rename upstream_url to download_url in license report
+- include upstream_url / download_url on more component types in license report
 
 ## [0.1.12] - 2023-04-03
 ### Changed


### PR DESCRIPTION
@JakubFrejlach or @JimFuller-RedHat Please review. This will add license_concluded to the OSC report when available, so OSC can use it (if desired) when license_declared is missing.

It also changes the "upstream_url" field to be called download_url, to match the Corgi API. This is always a download URL for a binary or source artifact. The related_url field is usually a human-readable about page, so is a better choice if you want an "upstream project URL". But I really think making the field names in the report different from the field names in the Corgi API will just cause confusion, so it's better if they match.

Finally, this expands the list of component types that report a download_url. RPMs use a generic page and RPMMODs have no download_url at all, so these are excluded. Containers sometimes have a specific URL and sometimes only a generic URL, so we report the container's specific download_url when available and skip it otherwise. Most remote-source components should have a download_url, so we report this in all cases.

There are some exceptions but I'd rather not clutter up the code to deal with edge cases. If some component does have a download_url, we can report it, and if it's missing OSC can just ignore that when building their report.