### PR TITLE
GRIF-71: speed up --search-related-urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- speed up griffon service products-contain-component with --search-related-urls
 
 ## [0.1.15] - 2023-04-11
 ### Changed


### PR DESCRIPTION
default search uses --search-latest and --search-related-urls ... this speeds up the --search-related-urls bit

>griffon service products-contain-component -s kernel