### PR TITLE
Various fixes

### DIFF
--- a/griffon/output.py
+++ b/griffon/output.py
@@ -172,6 +172,8 @@ def text_output_products_contain_component(
             for pv in product_versions:
                 names = [item["name"] for item in ordered_results if pv == item["product_version"]]
                 names = list(set(names))
+                if component_name in names and f"{component_name}-container" in names:
+                    names.remove(f"{component_name}-container")
                 for name in names:
                     if not any([match in name for match in exclude_components]):
                         dep_name = name
@@ -189,6 +191,8 @@ def text_output_products_contain_component(
                         item["name"] for item in ordered_results if pv == item["product_version"]
                     ]
                     names = list(set(names))
+                    if component_name in names and f"{component_name}-container" in names:
+                        names.remove(f"{component_name}-container")
                     for name in names:
                         if not any([match in name for match in exclude_components]):
                             dep_name = name.replace(component_name, f"[b]{component_name}[/b]")
@@ -208,6 +212,8 @@ def text_output_products_contain_component(
                         item for item in ordered_results if item["product_stream"] == ps
                     ]
                     names = sorted(list(set([item["name"] for item in ps_components])))
+                    if component_name in names and f"{component_name}-container" in names:
+                        names.remove(f"{component_name}-container")
 
                     for name in names:
                         if not any([match in name for match in exclude_components]):
@@ -238,6 +244,8 @@ def text_output_products_contain_component(
                         item for item in ordered_results if item["product_stream"] == ps
                     ]
                     names = sorted(list(set([item["name"] for item in ps_components])))
+                    if component_name in names and f"{component_name}-container" in names:
+                        names.remove(f"{component_name}-container")
 
                     for name in names:
                         if not any([match in name for match in exclude_components]):
@@ -271,6 +279,8 @@ def text_output_products_contain_component(
                         item for item in ordered_results if item["product_stream"] == ps
                     ]
                     names = sorted(list(set([item["name"] for item in ps_components])))
+                    if component_name in names and f"{component_name}-container" in names:
+                        names.remove(f"{component_name}-container")
                     for name in names:
                         if not any([match in name for match in exclude_components]):
                             sources = []
@@ -314,6 +324,8 @@ def text_output_products_contain_component(
                         item for item in ordered_results if item["product_stream"] == ps
                     ]
                     names = sorted(list(set([item["name"] for item in ps_components])))
+                    if component_name in names and f"{component_name}-container" in names:
+                        names.remove(f"{component_name}-container")
                     for name in names:
                         if not any([match in name for match in exclude_components]):
                             sources = []

--- a/griffon/services/core_queries.py
+++ b/griffon/services/core_queries.py
@@ -242,7 +242,7 @@ class products_containing_component_query:
             if self.component_type:
                 results = [result for result in results if result.type == self.component_type]
 
-        if self.search_community or self.search_related_url:
+        if self.search_related_url:
             # Note: related_url filter has no concept of strict
             params = {
                 "include_fields": "name,arch,release,version,nvr,type,link,software_build,product_versions,product_streams,sources,upstreams,namespace,purl",  # noqa


### PR DESCRIPTION
narrow down products-contain-component text output to only contain significant component (ex. remove {component}-container if {component} exists as well).