### PR TITLE
GRIF-132: fix error thrown when using partial .griffonrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+* ensure verbosity is always set
 
 ## [0.2.16] - 2023-08-08
 ### Changed

--- a/griffon/__init__.py
+++ b/griffon/__init__.py
@@ -72,9 +72,7 @@ griffon_config = get_config()
 def get_config_option(section, option, default_value=None):
     if griffon_config.has_option(section, option):
         return griffon_config.get(section, option)
-    if default_value:
-        return default_value
-    return None
+    return default_value
 
 
 def list_config_sections():

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -108,7 +108,6 @@ queries_grp.add_command(generate_license_report)
 @progress_bar
 def get_product_summary(ctx, product_stream_name, strict_name_search, all, verbose):
     """get product stream."""
-    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
     if not product_stream_name and not all and not strict_name_search:
@@ -325,7 +324,6 @@ def get_product_contain_component(
 ):
     with console.status("griffoning", spinner="line") as operation_status:
         """List products of a latest component."""
-        ctx.obj["VERBOSE"] = 0
         if verbose:
             ctx.obj["VERBOSE"] = verbose
         if not purl and not component_name:
@@ -585,7 +583,6 @@ def get_component_contain_component(
     verbose,
 ):
     """List components that contain component."""
-    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
     if not component_name and not purl:
@@ -656,7 +653,6 @@ def get_product_manifest_query(ctx, product_stream_name, ofuri, spdx_json_format
 @click.pass_context
 def get_product_latest_components_query(ctx, product_stream_name, ofuri, verbose, **params):
     """List components of a specific product version."""
-    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
         ctx.params.pop("verbose")

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -108,6 +108,7 @@ queries_grp.add_command(generate_license_report)
 @progress_bar
 def get_product_summary(ctx, product_stream_name, strict_name_search, all, verbose):
     """get product stream."""
+    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
     if not product_stream_name and not all and not strict_name_search:
@@ -324,6 +325,7 @@ def get_product_contain_component(
 ):
     with console.status("griffoning", spinner="line") as operation_status:
         """List products of a latest component."""
+        ctx.obj["VERBOSE"] = 0
         if verbose:
             ctx.obj["VERBOSE"] = verbose
         if not purl and not component_name:
@@ -583,6 +585,7 @@ def get_component_contain_component(
     verbose,
 ):
     """List components that contain component."""
+    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
     if not component_name and not purl:
@@ -653,6 +656,7 @@ def get_product_manifest_query(ctx, product_stream_name, ofuri, spdx_json_format
 @click.pass_context
 def get_product_latest_components_query(ctx, product_stream_name, ofuri, verbose, **params):
     """List components of a specific product version."""
+    ctx.obj["VERBOSE"] = 0
     if verbose:
         ctx.obj["VERBOSE"] = verbose
         ctx.params.pop("verbose")


### PR DESCRIPTION
griffon will not throw an error when using a partial .griffonrc, for example

```
[default]
output = text
[profile1]
details = foo
```
profile should not throw an error.
