### PR TITLE
Fix missing product versions during affect generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+* process all product version upon generating affects
 ## [0.3.4] - 2023-08-31
+### Changed
 * ensure we select released components
 
 ## [0.3.3] - 2023-08-31
+### Changed
 * minor perf enhancements
 
 ## [0.3.2] - 2023-08-29
+### Added
 * added back parallism for resolving sub resources (sources & upstreams)
 * added back upstream retrieval when performing --search-all
 

--- a/griffon/helpers.py
+++ b/griffon/helpers.py
@@ -1,0 +1,63 @@
+"""
+Helpers for direct usage or debbuging
+"""
+import json
+from typing import Callable, Optional, Type, Union
+
+from component_registry_bindings.bindings.python_client.types import (
+    ComponentRegistryModel,
+)
+from osidb_bindings.bindings.python_client.types import OSIDBModel
+
+
+def debug_data_dump(filename: str, data, transform_fn: Optional[Callable] = None):
+    """
+    Debugging utility to avoid heavy HTTP data transfers.
+    Serializes the data into JSON and dumps that into a
+    specified file.
+
+    transform function can be used for postprocessing the data after
+    the basic dict serialization
+
+    """
+    if isinstance(data, list):
+        json_data = [
+            item.to_dict() if isinstance(item, (ComponentRegistryModel, OSIDBModel)) else item
+            for item in data
+        ]
+
+        if transform_fn is not None:
+            json_data = list(map(transform_fn, json_data))
+
+    else:
+        json_data = data
+
+    with open(filename, "w") as fp:
+        json.dump(json_data, fp)
+
+
+def debug_data_load(
+    filename: str,
+    model: Optional[Union[Type[ComponentRegistryModel], Type[OSIDBModel]]] = None,
+    transform_fn: Optional[Callable] = None,
+):
+    """
+    Debugging utility to avoid heavy HTTP data transfers.
+    Loads the data from specified JSON file and transforms them
+    back into internal models.
+
+    transform function can be used for preprocessing the data before
+    the internal model transformation
+    """
+    with open(filename) as fp:
+        json_data = json.load(fp)
+
+    if isinstance(json_data, list):
+        if transform_fn is not None:
+            json_data = list(map(transform_fn, json_data))
+
+        data = [model.from_dict(item) for item in json_data]
+
+    else:
+        data = json_data
+    return data

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -265,6 +265,8 @@ def generate_affects(
     ctx, result_tree, exclude_components, flaw_operation, format="text", no_wrap=False
 ):
     search_component_name = ctx.params["component_name"]
+    affects = []
+
     for pv in result_tree.keys():
         component_names = set()
         for ps in result_tree[pv].keys():
@@ -299,14 +301,13 @@ def generate_affects(
                         no_wrap=no_wrap,
                     )
         else:
-            affects = []
             for cn in component_names:
                 # ensure {component name} is not in profile exclude components enum
                 if not any([re.search(match, cn) for match in exclude_components]):
                     affects.append(
                         {"product_version": pv, "component_name": cn, "operation": flaw_operation}
                     )
-            return affects
+    return affects
 
 
 def text_output_products_contain_component(


### PR DESCRIPTION
This PR fixes incorrect handling of product versions during the affect generation which resulted into processing only the first product version.

Also couple of debugging functions for developers were added so one can avoid repeated data heavy HTTP requests during the development.

Fixes GRIF-180

