### PR TITLE
Fix affect sorting with no CVE ID attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+* Fix affects sorting with no CVE ID attached in component-flaws output
 
 ## [0.3.7] - 2023-09-06
 ### Added

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -916,8 +916,9 @@ def text_output_component_flaws(ctx, output, format, no_wrap=False):
     ordered_components = sorted(output["results"], key=lambda d: d["name"])
     for item in ordered_components:
         component_name = item["name"]
-        # sorting should work when there is no title or cve-id key
-        ordered_affects = sorted(item["affects"], key=lambda d: d["flaw_cve_id"])
+        ordered_affects = sorted(
+            item["affects"], key=lambda d: (d["flaw_cve_id"] is None, d["flaw_cve_id"])
+        )
         for affect in ordered_affects:
             flaw_cve_id = "Vulnerability"
             if affect["flaw_cve_id"]:


### PR DESCRIPTION
Fixes the `TypeError: '<' not supported between instances of 'NoneType' and 'str'` for component-flaws query tracked in GRIF-115.