### PR TITLE
Bump tox version used in github workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get install gcc libkrb5-dev krb5-user
           sudo ln -s /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /usr/lib/libgssapi_krb5.so
       - name: Install tox
-        run: pip install tox==3.24.5
+        run: pip install tox==4.11.1
       - name: Check that code is formatted with black
         run: tox -e black
   isort:
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install gcc libkrb5-dev krb5-user
           sudo ln -s /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /usr/lib/libgssapi_krb5.so
       - name: Install tox
-        run: pip install tox==3.24.5
+        run: pip install tox==4.11.1
       - name: Check that imports are formatted with isort
         run: tox -e isort
   flake8:
@@ -46,6 +46,6 @@ jobs:
           sudo apt-get install gcc libkrb5-dev krb5-user
           sudo ln -s /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /usr/lib/libgssapi_krb5.so
       - name: Install tox
-        run: pip install tox==3.24.5
+        run: pip install tox==4.11.1
       - name: Check that imports are formatted with isort
         run: tox -e flake8


### PR DESCRIPTION
Oddly enough, all actions using `tox` right now are currently erroring out. In #268 migration from `setup.py` to `pyproject.toml` was introduced which required tox to use `isolated_build=true` option. Apparently this option is present in tox from version 3.3.0 based on the docs, however we were running tox 3.24.5. I am no entirely sure how come that previously actions went OK and it is erroring out only now, but bumping the tox version should fir this problem.