### PR TITLE
GRIF-121 Filter RH naming by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+* --filter-rh-naming enabled by default (GRIF-121)
+
+### Added
+ * --filter-rh-naming default value can be set via .griffonrc 
+   in default section(GRIG-121)
+
 
 ## [0.5.0] - 2024-01-18
 

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -265,10 +265,9 @@ def retrieve_component_summary(ctx, component_name, strict_name_search, operatio
     help=f"Search related url {Style.BOLD}(enabled by default){Style.RESET}.",
 )
 @click.option(
-    "--filter-rh-naming",
-    is_flag=True,
-    default=False,
-    help="Filter rh naming.",
+    "--filter-rh-naming/--no-filter-rh-naming",
+    default=get_config_option("default", "filter_rh_naming", True),
+    help="Do not filter RH naming.",
 )
 @click.option(
     "--search-all",

--- a/griffon/static/default_griffonrc
+++ b/griffon/static/default_griffonrc
@@ -22,6 +22,7 @@ exclude_components = -container-source
     -repolib
 include_container_roots = False
 exclude_unreleased = False
+filter_rh_naming = True
 
 # profile sections (use with --profile {profile} flag)
 [cloud]


### PR DESCRIPTION
This PR:
* enables `--filter-rh-naming` by default
* makes `--filter-rh-naming` settable from the .griffonrc file