### PR TITLE
Minor: reimpl --include-container-roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 * --filter-rh-naming enabled by default (GRIF-121)
+* --include-root-containers filters on the query (not the output)
 
 ### Added
  * --filter-rh-naming default value can be set via .griffonrc 

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -415,7 +415,6 @@ def get_product_contain_component(
     """List products of a latest component."""
     if verbose:
         ctx.obj["VERBOSE"] = verbose
-    ctx.obj["INCLUDE_CONTAINER_ROOTS"] = include_container_roots
     ctx.obj["REGEX_NAME_SEARCH"] = regex_name_search
     if (
         not search_latest
@@ -435,7 +434,6 @@ def get_product_contain_component(
     params.pop("sfm2_flaw_id")
     params.pop("flaw_mode")
     params.pop("affect_mode")
-    params.pop("include_container_roots")
     if component_name:
         q = query_service.invoke(
             core_queries.products_containing_component_query, params, status=operation_status

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -470,66 +470,60 @@ def text_output_products_contain_component(
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = list(result_tree[pv][ps][cn].keys())[-1]
-                            if result_tree[pv][ps][cn][nvr]["type"] != "OCI" or (
-                                result_tree[pv][ps][cn][nvr]["type"] == "OCI"
-                                and ctx.obj["INCLUDE_CONTAINER_ROOTS"]
-                            ):
-                                product_color = process_product_color(
-                                    result_tree[pv][ps][cn][nvr]["build_type"]
-                                )
-                                dep_name = nvr
-                                # highlight search term
-                                try:
-                                    dep_name = highlight_search_term(
-                                        search_component_name, dep_name
+                            product_color = process_product_color(
+                                result_tree[pv][ps][cn][nvr]["build_type"]
+                            )
+                            dep_name = nvr
+                            # highlight search term
+                            try:
+                                dep_name = highlight_search_term(search_component_name, dep_name)
+                            except re.error:
+                                pass
+                            dep = f"[grey93]{dep_name}[/grey93]"  # noqa
+                            if result_tree[pv][ps][cn][nvr]["upstreams"]:
+                                upstream_component_names = sorted(
+                                    list(
+                                        [
+                                            f"{upstream['name']} {upstream['version']}"
+                                            for upstream in result_tree[pv][ps][cn][nvr][
+                                                "upstreams"
+                                            ]
+                                        ]
                                     )
-                                except re.error:
-                                    pass
-                                dep = f"[grey93]{dep_name}[/grey93]"  # noqa
-                                if result_tree[pv][ps][cn][nvr]["upstreams"]:
-                                    upstream_component_names = sorted(
-                                        list(
+                                )
+                                for upstream_component_name in upstream_component_names:
+                                    console.print(
+                                        Text(pv, style="bright_red b"),
+                                        upstream_component_name,
+                                        no_wrap=no_wrap,
+                                    )
+                            if result_tree[pv][ps][cn][nvr]["sources"]:
+                                source_component_names = sorted(
+                                    list(
+                                        set(
                                             [
-                                                f"{upstream['name']} {upstream['version']}"
-                                                for upstream in result_tree[pv][ps][cn][nvr][
-                                                    "upstreams"
+                                                f"{source['name']} {source['version']}"
+                                                for source in result_tree[pv][ps][cn][nvr][
+                                                    "sources"
                                                 ]
                                             ]
                                         )
                                     )
-                                    for upstream_component_name in upstream_component_names:
-                                        console.print(
-                                            Text(pv, style="bright_red b"),
-                                            upstream_component_name,
-                                            no_wrap=no_wrap,
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["sources"]:
-                                    source_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{source['name']} {source['version']}"
-                                                    for source in result_tree[pv][ps][cn][nvr][
-                                                        "sources"
-                                                    ]
-                                                ]
-                                            )
-                                        )
-                                    )
-                                    for source_component_name in source_component_names:
-                                        console.print(
-                                            Text(pv, style="bright_red b"),
-                                            source_component_name,
-                                            no_wrap=no_wrap,
-                                        )
-                                if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
-                                    result_tree[pv][ps][cn][nvr]["sources"]
-                                ):
+                                )
+                                for source_component_name in source_component_names:
                                     console.print(
-                                        Text(pv, style=f"{product_color} b"),
-                                        dep,
+                                        Text(pv, style="bright_red b"),
+                                        source_component_name,
                                         no_wrap=no_wrap,
                                     )
+                            if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
+                                result_tree[pv][ps][cn][nvr]["sources"]
+                            ):
+                                console.print(
+                                    Text(pv, style=f"{product_color} b"),
+                                    dep,
+                                    no_wrap=no_wrap,
+                                )
             if (
                 ctx.obj["VERBOSE"] == 1
             ):  # product_stream X root component nvr (type) x child components [nvr (type)]
@@ -538,131 +532,121 @@ def text_output_products_contain_component(
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = list(result_tree[pv][ps][cn].keys())[-1]
-                            if result_tree[pv][ps][cn][nvr]["type"] != "OCI" or (
-                                result_tree[pv][ps][cn][nvr]["type"] == "OCI"
-                                and ctx.obj["INCLUDE_CONTAINER_ROOTS"]
-                            ):
-                                product_color = process_product_color(
-                                    result_tree[pv][ps][cn][nvr]["build_type"]
-                                )
-                                # highlight search term
-                                # dep_name = nvr
-                                dep_name = nvr
-                                try:
-                                    dep_name = highlight_search_term(
-                                        search_component_name, dep_name
+                            product_color = process_product_color(
+                                result_tree[pv][ps][cn][nvr]["build_type"]
+                            )
+                            # highlight search term
+                            # dep_name = nvr
+                            dep_name = nvr
+                            try:
+                                dep_name = highlight_search_term(search_component_name, dep_name)
+                            except re.error:
+                                pass
+                            dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']})[/grey93]"  # noqa
+                            related_url = result_tree[pv][ps][cn][nvr].get("related_url")
+                            try:
+                                if result_tree[pv][ps][cn][nvr]["related_url"]:
+                                    related_url = highlight_search_term(
+                                        search_component_name,
+                                        result_tree[pv][ps][cn][nvr]["related_url"],
                                     )
-                                except re.error:
-                                    pass
-                                dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']})[/grey93]"  # noqa
-                                related_url = result_tree[pv][ps][cn][nvr].get("related_url")
-                                try:
-                                    if result_tree[pv][ps][cn][nvr]["related_url"]:
-                                        related_url = highlight_search_term(
-                                            search_component_name,
-                                            result_tree[pv][ps][cn][nvr]["related_url"],
-                                        )
-                                except re.error:
-                                    pass
-                                provides_components = []
-                                if "provides" in result_tree[pv][ps][cn][nvr]:
-                                    provides_component_names = set(
+                            except re.error:
+                                pass
+                            provides_components = []
+                            if "provides" in result_tree[pv][ps][cn][nvr]:
+                                provides_component_names = set(
+                                    [
+                                        provide["name"]
+                                        for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                    ]
+                                )
+                                for provide_name in provides_component_names:
+                                    versions = set(
                                         [
-                                            provide["name"]
+                                            provide["version"]
                                             for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                            if provide["name"] == provide_name
                                         ]
                                     )
-                                    for provide_name in provides_component_names:
-                                        versions = set(
+                                    types = set(
+                                        [
+                                            provide["type"]
+                                            for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                            if provide["name"] == provide_name
+                                        ]
+                                    )
+                                    provides_components.append(
+                                        f"{provide_name} {(','.join(versions))} ({(',').join(types)})"  # noqa
+                                    )
+                            if result_tree[pv][ps][cn][nvr]["upstreams"]:
+                                upstream_component_names = sorted(
+                                    list(
+                                        set(
                                             [
-                                                provide["version"]
-                                                for provide in result_tree[pv][ps][cn][nvr][
-                                                    "provides"
+                                                f"{upstream['nvr']} ({upstream['type']})"
+                                                for upstream in result_tree[pv][ps][cn][nvr][
+                                                    "upstreams"
                                                 ]
-                                                if provide["name"] == provide_name
                                             ]
                                         )
-                                        types = set(
-                                            [
-                                                provide["type"]
-                                                for provide in result_tree[pv][ps][cn][nvr][
-                                                    "provides"
-                                                ]
-                                                if provide["name"] == provide_name
-                                            ]
-                                        )
-                                        provides_components.append(
-                                            f"{provide_name} {(','.join(versions))} ({(',').join(types)})"  # noqa
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["upstreams"]:
-                                    upstream_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{upstream['nvr']} ({upstream['type']})"
-                                                    for upstream in result_tree[pv][ps][cn][nvr][
-                                                        "upstreams"
-                                                    ]
-                                                ]
-                                            )
-                                        )
                                     )
-                                    if len(upstream_component_names) > 0:
-                                        upstream_component_name = (
-                                            f"[cyan]{upstream_component_names[0]}[/cyan]"
-                                        )
-                                        if len(upstream_component_names) > 1:
-                                            upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            upstream_component_name,
-                                            dep,
-                                            no_wrap=no_wrap,
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["sources"]:
-                                    source_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{source['nvr']} ({source['type']})"
-                                                    for source in result_tree[pv][ps][cn][nvr][
-                                                        "sources"
-                                                    ]
-                                                ]
-                                            )
-                                        )
+                                )
+                                if len(upstream_component_names) > 0:
+                                    upstream_component_name = (
+                                        f"[cyan]{upstream_component_names[0]}[/cyan]"
                                     )
-                                    if len(source_component_names) > 0:
-                                        source_component_name = (
-                                            f"[red]{source_component_names[0]}[/red]"
-                                        )
-                                        if len(source_component_names) > 1:
-                                            source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            source_component_name,
-                                            dep,
-                                            no_wrap=no_wrap,
-                                        )
-                                if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
-                                    result_tree[pv][ps][cn][nvr]["sources"]
-                                ):
-                                    child_dep_names = ""
-                                    if provides_components:
-                                        try:
-                                            child_dep_names = highlight_search_term(
-                                                search_component_name,
-                                                ", ".join(provides_components),
-                                            )
-                                            child_dep_names = f"[{child_dep_names}]"
-                                        except re.error:
-                                            pass
+                                    if len(upstream_component_names) > 1:
+                                        upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
                                     console.print(
                                         Text(ps, style=f"{product_color} b"),
+                                        upstream_component_name,
                                         dep,
-                                        child_dep_names,
                                         no_wrap=no_wrap,
                                     )
+                            if result_tree[pv][ps][cn][nvr]["sources"]:
+                                source_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                f"{source['nvr']} ({source['type']})"
+                                                for source in result_tree[pv][ps][cn][nvr][
+                                                    "sources"
+                                                ]
+                                            ]
+                                        )
+                                    )
+                                )
+                                if len(source_component_names) > 0:
+                                    source_component_name = (
+                                        f"[red]{source_component_names[0]}[/red]"
+                                    )
+                                    if len(source_component_names) > 1:
+                                        source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
+                                    console.print(
+                                        Text(ps, style=f"{product_color} b"),
+                                        source_component_name,
+                                        dep,
+                                        no_wrap=no_wrap,
+                                    )
+                            if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
+                                result_tree[pv][ps][cn][nvr]["sources"]
+                            ):
+                                child_dep_names = ""
+                                if provides_components:
+                                    try:
+                                        child_dep_names = highlight_search_term(
+                                            search_component_name,
+                                            ", ".join(provides_components),
+                                        )
+                                        child_dep_names = f"[{child_dep_names}]"
+                                    except re.error:
+                                        pass
+                                console.print(
+                                    Text(ps, style=f"{product_color} b"),
+                                    dep,
+                                    child_dep_names,
+                                    no_wrap=no_wrap,
+                                )
             if (
                 ctx.obj["VERBOSE"] == 2
             ):  # product_stream X root component nvr (type:arch) x child components [name {versions} (type:{arches})] x related_url x build_source_url # noqa
@@ -671,152 +655,140 @@ def text_output_products_contain_component(
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = list(result_tree[pv][ps][cn].keys())[-1]
-                            if result_tree[pv][ps][cn][nvr]["type"] != "OCI" or (
-                                result_tree[pv][ps][cn][nvr]["type"] == "OCI"
-                                and ctx.obj["INCLUDE_CONTAINER_ROOTS"]
-                            ):
-                                product_color = process_product_color(
-                                    result_tree[pv][ps][cn][nvr]["build_type"]
+                            product_color = process_product_color(
+                                result_tree[pv][ps][cn][nvr]["build_type"]
+                            )
+                            # highlight search term
+                            dep_name = nvr
+                            try:
+                                dep_name = highlight_search_term(
+                                    search_component_name,
+                                    dep_name,
                                 )
-                                # highlight search term
-                                dep_name = nvr
-                                try:
-                                    dep_name = highlight_search_term(
+                            except re.error:
+                                pass
+                            dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']}:{result_tree[pv][ps][cn][nvr]['arch']})[/grey93]"  # noqa
+                            related_url = result_tree[pv][ps][cn][nvr].get("related_url")
+                            try:
+                                if result_tree[pv][ps][cn][nvr]["related_url"]:
+                                    related_url = highlight_search_term(
                                         search_component_name,
-                                        dep_name,
+                                        result_tree[pv][ps][cn][nvr]["related_url"],
                                     )
-                                except re.error:
-                                    pass
-                                dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']}:{result_tree[pv][ps][cn][nvr]['arch']})[/grey93]"  # noqa
-                                related_url = result_tree[pv][ps][cn][nvr].get("related_url")
-                                try:
-                                    if result_tree[pv][ps][cn][nvr]["related_url"]:
-                                        related_url = highlight_search_term(
-                                            search_component_name,
-                                            result_tree[pv][ps][cn][nvr]["related_url"],
-                                        )
 
-                                except re.error:
-                                    pass
-                                build_source_url = ""
-                                if result_tree[pv][ps][cn][nvr]["build_source_url"]:
-                                    build_source_url = result_tree[pv][ps][cn][nvr][
-                                        "build_source_url"
+                            except re.error:
+                                pass
+                            build_source_url = ""
+                            if result_tree[pv][ps][cn][nvr]["build_source_url"]:
+                                build_source_url = result_tree[pv][ps][cn][nvr]["build_source_url"]
+                            provides_components = []
+                            if "provides" in result_tree[pv][ps][cn][nvr]:
+                                provides_component_names = set(
+                                    [
+                                        provide["name"]
+                                        for provide in result_tree[pv][ps][cn][nvr]["provides"]
                                     ]
-                                provides_components = []
-                                if "provides" in result_tree[pv][ps][cn][nvr]:
-                                    provides_component_names = set(
+                                )
+                                for provide_name in provides_component_names:
+                                    versions = set(
                                         [
-                                            provide["name"]
+                                            provide["version"]
                                             for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                            if provide["name"] == provide_name
                                         ]
                                     )
-                                    for provide_name in provides_component_names:
-                                        versions = set(
+                                    types = set(
+                                        [
+                                            provide["type"]
+                                            for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                            if provide["name"] == provide_name
+                                        ]
+                                    )
+                                    arches = set(
+                                        [
+                                            provide["arch"]
+                                            for provide in result_tree[pv][ps][cn][nvr]["provides"]
+                                            if provide["name"] == provide_name
+                                        ]
+                                    )
+                                    provides_components.append(
+                                        f"{provide_name} {(','.join(versions))} ({(',').join(types)}:{','.join(arches)})"  # noqa
+                                    )
+                            if result_tree[pv][ps][cn][nvr]["upstreams"]:
+                                upstream_component_names = sorted(
+                                    list(
+                                        set(
                                             [
-                                                provide["version"]
-                                                for provide in result_tree[pv][ps][cn][nvr][
-                                                    "provides"
+                                                f"{upstream['nvr']} ({upstream['type']}:{upstream['arch']})"  # noqa
+                                                for upstream in result_tree[pv][ps][cn][nvr][
+                                                    "upstreams"
                                                 ]
-                                                if provide["name"] == provide_name
                                             ]
-                                        )
-                                        types = set(
-                                            [
-                                                provide["type"]
-                                                for provide in result_tree[pv][ps][cn][nvr][
-                                                    "provides"
-                                                ]
-                                                if provide["name"] == provide_name
-                                            ]
-                                        )
-                                        arches = set(
-                                            [
-                                                provide["arch"]
-                                                for provide in result_tree[pv][ps][cn][nvr][
-                                                    "provides"
-                                                ]
-                                                if provide["name"] == provide_name
-                                            ]
-                                        )
-                                        provides_components.append(
-                                            f"{provide_name} {(','.join(versions))} ({(',').join(types)}:{','.join(arches)})"  # noqa
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["upstreams"]:
-                                    upstream_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{upstream['nvr']} ({upstream['type']}:{upstream['arch']})"  # noqa
-                                                    for upstream in result_tree[pv][ps][cn][nvr][
-                                                        "upstreams"
-                                                    ]
-                                                ]
-                                            )
                                         )
                                     )
-                                    if len(upstream_component_names) > 0:
-                                        upstream_component_name = (
-                                            f"[cyan]{upstream_component_names[0]}[/cyan]"
-                                        )
-                                        if len(upstream_component_names) > 1:
-                                            upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            upstream_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["sources"]:
-                                    source_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{source['nvr']} ({source['type']}:{source['arch']})"  # noqa
-                                                    for source in result_tree[pv][ps][cn][nvr][
-                                                        "sources"
-                                                    ]
-                                                ]
-                                            )
-                                        )
+                                )
+                                if len(upstream_component_names) > 0:
+                                    upstream_component_name = (
+                                        f"[cyan]{upstream_component_names[0]}[/cyan]"
                                     )
-                                    if len(source_component_names) > 0:
-                                        source_component_name = (
-                                            f"[red]{source_component_names[0]}[/red]"
-                                        )
-                                        if len(source_component_names) > 1:
-                                            source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            source_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
-                                    result_tree[pv][ps][cn][nvr]["sources"]
-                                ):
-                                    child_dep_names = ""
-                                    if provides_components:
-                                        try:
-                                            child_dep_names = highlight_search_term(
-                                                search_component_name,
-                                                ", ".join(provides_components),
-                                            )
-                                            child_dep_names = f"[{child_dep_names}]"
-                                        except re.error:
-                                            pass
-
+                                    if len(upstream_component_names) > 1:
+                                        upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
                                     console.print(
                                         Text(ps, style=f"{product_color} b"),
+                                        upstream_component_name,
                                         dep,
-                                        child_dep_names,
-                                        f"[i][grey]{related_url}[/grey][/i]",
-                                        f"[i][grey]{build_source_url}[/grey][/i]",
-                                        width=1000,
+                                        f"[grey]{related_url}[/grey]",
                                         no_wrap=no_wrap,
                                     )
+                            if result_tree[pv][ps][cn][nvr]["sources"]:
+                                source_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                f"{source['nvr']} ({source['type']}:{source['arch']})"  # noqa
+                                                for source in result_tree[pv][ps][cn][nvr][
+                                                    "sources"
+                                                ]
+                                            ]
+                                        )
+                                    )
+                                )
+                                if len(source_component_names) > 0:
+                                    source_component_name = (
+                                        f"[red]{source_component_names[0]}[/red]"
+                                    )
+                                    if len(source_component_names) > 1:
+                                        source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
+                                    console.print(
+                                        Text(ps, style=f"{product_color} b"),
+                                        source_component_name,
+                                        dep,
+                                        f"[grey]{related_url}[/grey]",
+                                        no_wrap=no_wrap,
+                                    )
+                            if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
+                                result_tree[pv][ps][cn][nvr]["sources"]
+                            ):
+                                child_dep_names = ""
+                                if provides_components:
+                                    try:
+                                        child_dep_names = highlight_search_term(
+                                            search_component_name,
+                                            ", ".join(provides_components),
+                                        )
+                                        child_dep_names = f"[{child_dep_names}]"
+                                    except re.error:
+                                        pass
+
+                                console.print(
+                                    Text(ps, style=f"{product_color} b"),
+                                    dep,
+                                    child_dep_names,
+                                    f"[i][grey]{related_url}[/grey][/i]",
+                                    f"[i][grey]{build_source_url}[/grey][/i]",
+                                    width=1000,
+                                    no_wrap=no_wrap,
+                                )
             if (
                 ctx.obj["VERBOSE"] == 3
             ):  # product_stream X root component nvr (type:arch) x child components [ nvr (type:arch)] x related_url x build_source_url # noqa
@@ -825,118 +797,112 @@ def text_output_products_contain_component(
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = list(result_tree[pv][ps][cn].keys())[-1]
-                            if result_tree[pv][ps][cn][nvr]["type"] != "OCI" or (
-                                result_tree[pv][ps][cn][nvr]["type"] == "OCI"
-                                and ctx.obj["INCLUDE_CONTAINER_ROOTS"]
-                            ):
-                                product_color = process_product_color(
-                                    result_tree[pv][ps][cn][nvr]["build_type"]
+                            product_color = process_product_color(
+                                result_tree[pv][ps][cn][nvr]["build_type"]
+                            )
+                            # highlight search term
+                            dep_name = nvr
+                            try:
+                                dep_name = highlight_search_term(
+                                    search_component_name,
+                                    dep_name,
                                 )
-                                # highlight search term
-                                dep_name = nvr
-                                try:
-                                    dep_name = highlight_search_term(
+                            except re.error:
+                                pass
+                            dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']}:{result_tree[pv][ps][cn][nvr]['arch']})[/grey93]"  # noqa
+                            related_url = result_tree[pv][ps][cn][nvr].get("related_url")
+                            try:
+                                if result_tree[pv][ps][cn][nvr]["related_url"]:
+                                    related_url = highlight_search_term(
                                         search_component_name,
-                                        dep_name,
+                                        result_tree[pv][ps][cn][nvr]["related_url"],
                                     )
-                                except re.error:
-                                    pass
-                                dep = f"[grey93]{dep_name} ({result_tree[pv][ps][cn][nvr]['type']}:{result_tree[pv][ps][cn][nvr]['arch']})[/grey93]"  # noqa
-                                related_url = result_tree[pv][ps][cn][nvr].get("related_url")
-                                try:
-                                    if result_tree[pv][ps][cn][nvr]["related_url"]:
-                                        related_url = highlight_search_term(
-                                            search_component_name,
-                                            result_tree[pv][ps][cn][nvr]["related_url"],
-                                        )
-                                except re.error:
-                                    pass
-                                build_source_url = ""
-                                if result_tree[pv][ps][cn][nvr]["build_source_url"]:
-                                    build_source_url = result_tree[pv][ps][cn][nvr][
-                                        "build_source_url"
-                                    ]
-                                provides_components = []
-                                if "provides" in result_tree[pv][ps][cn][nvr]:
-                                    for provide in result_tree[pv][ps][cn][nvr]["provides"]:
-                                        provides_components.append(
-                                            f"{provide['nvr']} ({provide['type']}:{provide['arch']})"  # noqa
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["upstreams"]:
-                                    upstream_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{upstream['nvr']} ({upstream['type']}:{upstream['arch']})"  # noqa
-                                                    for upstream in result_tree[pv][ps][cn][nvr][
-                                                        "upstreams"
-                                                    ]
+                            except re.error:
+                                pass
+                            build_source_url = ""
+                            if result_tree[pv][ps][cn][nvr]["build_source_url"]:
+                                build_source_url = result_tree[pv][ps][cn][nvr]["build_source_url"]
+                            provides_components = []
+                            if "provides" in result_tree[pv][ps][cn][nvr]:
+                                for provide in result_tree[pv][ps][cn][nvr]["provides"]:
+                                    provides_components.append(
+                                        f"{provide['nvr']} ({provide['type']}:{provide['arch']})"  # noqa
+                                    )
+                            if result_tree[pv][ps][cn][nvr]["upstreams"]:
+                                upstream_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                f"{upstream['nvr']} ({upstream['type']}:{upstream['arch']})"  # noqa
+                                                for upstream in result_tree[pv][ps][cn][nvr][
+                                                    "upstreams"
                                                 ]
-                                            )
+                                            ]
                                         )
                                     )
-                                    if len(upstream_component_names) > 0:
-                                        upstream_component_name = (
-                                            f"[cyan]{upstream_component_names[0]}[/cyan]"
-                                        )
-                                        if len(upstream_component_names) > 1:
-                                            upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            upstream_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["sources"]:
-                                    source_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    f"{source['nvr']} ({source['type']}:{source['arch']})"  # noqa
-                                                    for source in result_tree[pv][ps][cn][nvr][
-                                                        "sources"
-                                                    ]
-                                                ]
-                                            )
-                                        )
+                                )
+                                if len(upstream_component_names) > 0:
+                                    upstream_component_name = (
+                                        f"[cyan]{upstream_component_names[0]}[/cyan]"
                                     )
-                                    if len(source_component_names) > 0:
-                                        source_component_name = (
-                                            f"[red]{source_component_names[0]}[/red]"
-                                        )
-                                        if len(source_component_names) > 1:
-                                            source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b"),
-                                            source_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
-                                    result_tree[pv][ps][cn][nvr]["sources"]
-                                ):
-                                    child_dep_names = ""
-                                    if provides_components:
-                                        try:
-                                            child_dep_names = highlight_search_term(
-                                                search_component_name,
-                                                ", ".join(provides_components),
-                                            )
-                                            child_dep_names = f"[{child_dep_names}]"
-                                        except re.error:
-                                            pass
-
+                                    if len(upstream_component_names) > 1:
+                                        upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
                                     console.print(
                                         Text(ps, style=f"{product_color} b"),
+                                        upstream_component_name,
                                         dep,
-                                        child_dep_names,
-                                        f"[i][grey]{related_url}[/grey][/i]",
-                                        f"[i][grey]{build_source_url}[/grey][/i]",
-                                        width=1000,
+                                        f"[grey]{related_url}[/grey]",
                                         no_wrap=no_wrap,
                                     )
+                            if result_tree[pv][ps][cn][nvr]["sources"]:
+                                source_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                f"{source['nvr']} ({source['type']}:{source['arch']})"  # noqa
+                                                for source in result_tree[pv][ps][cn][nvr][
+                                                    "sources"
+                                                ]
+                                            ]
+                                        )
+                                    )
+                                )
+                                if len(source_component_names) > 0:
+                                    source_component_name = (
+                                        f"[red]{source_component_names[0]}[/red]"
+                                    )
+                                    if len(source_component_names) > 1:
+                                        source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
+                                    console.print(
+                                        Text(ps, style=f"{product_color} b"),
+                                        source_component_name,
+                                        dep,
+                                        f"[grey]{related_url}[/grey]",
+                                        no_wrap=no_wrap,
+                                    )
+                            if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
+                                result_tree[pv][ps][cn][nvr]["sources"]
+                            ):
+                                child_dep_names = ""
+                                if provides_components:
+                                    try:
+                                        child_dep_names = highlight_search_term(
+                                            search_component_name,
+                                            ", ".join(provides_components),
+                                        )
+                                        child_dep_names = f"[{child_dep_names}]"
+                                    except re.error:
+                                        pass
+
+                                console.print(
+                                    Text(ps, style=f"{product_color} b"),
+                                    dep,
+                                    child_dep_names,
+                                    f"[i][grey]{related_url}[/grey][/i]",
+                                    f"[i][grey]{build_source_url}[/grey][/i]",
+                                    width=1000,
+                                    no_wrap=no_wrap,
+                                )
             if (
                 ctx.obj["VERBOSE"] > 3
             ):  # product_stream X root component purl x child components [ purl ] x related_url x build_source_url # noqa
@@ -945,118 +911,112 @@ def text_output_products_contain_component(
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = list(result_tree[pv][ps][cn].keys())[-1]
-                            if result_tree[pv][ps][cn][nvr]["type"] != "OCI" or (
-                                result_tree[pv][ps][cn][nvr]["type"] == "OCI"
-                                and ctx.obj["INCLUDE_CONTAINER_ROOTS"]
-                            ):
-                                product_color = process_product_color(
-                                    result_tree[pv][ps][cn][nvr]["build_type"]
+                            product_color = process_product_color(
+                                result_tree[pv][ps][cn][nvr]["build_type"]
+                            )
+                            # highlight search term
+                            dep_name = result_tree[pv][ps][cn][nvr]["purl"]
+                            try:
+                                dep_name = highlight_search_term(
+                                    search_component_name,
+                                    dep_name,
                                 )
-                                # highlight search term
-                                dep_name = result_tree[pv][ps][cn][nvr]["purl"]
-                                try:
-                                    dep_name = highlight_search_term(
+                            except re.error:
+                                pass
+                            dep = f"[grey93]{dep_name}[/grey93]"  # noqa
+                            related_url = result_tree[pv][ps][cn][nvr].get("related_url")
+                            try:
+                                if result_tree[pv][ps][cn][nvr]["related_url"]:
+                                    related_url = highlight_search_term(
                                         search_component_name,
-                                        dep_name,
+                                        result_tree[pv][ps][cn][nvr]["related_url"],
                                     )
-                                except re.error:
-                                    pass
-                                dep = f"[grey93]{dep_name}[/grey93]"  # noqa
-                                related_url = result_tree[pv][ps][cn][nvr].get("related_url")
-                                try:
-                                    if result_tree[pv][ps][cn][nvr]["related_url"]:
-                                        related_url = highlight_search_term(
-                                            search_component_name,
-                                            result_tree[pv][ps][cn][nvr]["related_url"],
-                                        )
-                                except re.error:
-                                    pass
-                                build_source_url = ""
-                                if result_tree[pv][ps][cn][nvr]["build_source_url"]:
-                                    build_source_url = result_tree[pv][ps][cn][nvr][
-                                        "build_source_url"
-                                    ]
-                                provides_components = []
-                                if "provides" in result_tree[pv][ps][cn][nvr]:
-                                    for provide in result_tree[pv][ps][cn][nvr]["provides"]:
-                                        provides_components.append(f"{provide['purl']}")
-                                if result_tree[pv][ps][cn][nvr]["upstreams"]:
-                                    upstream_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    upstream["purl"]
-                                                    for upstream in result_tree[pv][ps][cn][nvr][
-                                                        "upstreams"
-                                                    ]
+                            except re.error:
+                                pass
+                            build_source_url = ""
+                            if result_tree[pv][ps][cn][nvr]["build_source_url"]:
+                                build_source_url = result_tree[pv][ps][cn][nvr]["build_source_url"]
+                            provides_components = []
+                            if "provides" in result_tree[pv][ps][cn][nvr]:
+                                for provide in result_tree[pv][ps][cn][nvr]["provides"]:
+                                    provides_components.append(f"{provide['purl']}")
+                            if result_tree[pv][ps][cn][nvr]["upstreams"]:
+                                upstream_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                upstream["purl"]
+                                                for upstream in result_tree[pv][ps][cn][nvr][
+                                                    "upstreams"
                                                 ]
-                                            )
+                                            ]
                                         )
                                     )
-                                    if len(upstream_component_names) > 0:
-                                        upstream_component_name = (
-                                            f"[cyan]{upstream_component_names[0]}[/cyan]"
-                                        )
-                                        if len(upstream_component_names) > 1:
-                                            upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b u"),
-                                            upstream_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            f"[grey]{build_source_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if result_tree[pv][ps][cn][nvr]["sources"]:
-                                    source_component_names = sorted(
-                                        list(
-                                            set(
-                                                [
-                                                    source["purl"]
-                                                    for source in result_tree[pv][ps][cn][nvr][
-                                                        "sources"
-                                                    ]
-                                                ]
-                                            )
-                                        )
+                                )
+                                if len(upstream_component_names) > 0:
+                                    upstream_component_name = (
+                                        f"[cyan]{upstream_component_names[0]}[/cyan]"
                                     )
-                                    if len(source_component_names) > 0:
-                                        source_component_name = (
-                                            f"[red]{source_component_names[0]}[/red]"
-                                        )
-                                        if len(source_component_names) > 1:
-                                            source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
-                                        console.print(
-                                            Text(ps, style=f"{product_color} b u"),
-                                            source_component_name,
-                                            dep,
-                                            f"[grey]{related_url}[/grey]",
-                                            f"[grey]{build_source_url}[/grey]",
-                                            no_wrap=no_wrap,
-                                        )
-                                if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
-                                    result_tree[pv][ps][cn][nvr]["sources"]
-                                ):
-                                    child_dep_names = ""
-                                    if provides_components:
-                                        try:
-                                            child_dep_names = highlight_search_term(
-                                                search_component_name,
-                                                ", ".join(provides_components),
-                                            )
-                                            child_dep_names = f"[{child_dep_names}]"
-                                        except re.error:
-                                            pass
-
+                                    if len(upstream_component_names) > 1:
+                                        upstream_component_name = f"[cyan]{upstream_component_names[0]} and {len(upstream_component_names) - 1} more[/cyan]"  # noqa
                                     console.print(
-                                        Text(ps, style=f"{product_color} b"),
+                                        Text(ps, style=f"{product_color} b u"),
+                                        upstream_component_name,
                                         dep,
-                                        child_dep_names,
-                                        f"[i][grey]{related_url}[/grey][/i]",
-                                        f"[i][grey]{build_source_url}[/grey][/i]",
-                                        width=10000,
+                                        f"[grey]{related_url}[/grey]",
+                                        f"[grey]{build_source_url}[/grey]",
                                         no_wrap=no_wrap,
                                     )
+                            if result_tree[pv][ps][cn][nvr]["sources"]:
+                                source_component_names = sorted(
+                                    list(
+                                        set(
+                                            [
+                                                source["purl"]
+                                                for source in result_tree[pv][ps][cn][nvr][
+                                                    "sources"
+                                                ]
+                                            ]
+                                        )
+                                    )
+                                )
+                                if len(source_component_names) > 0:
+                                    source_component_name = (
+                                        f"[red]{source_component_names[0]}[/red]"
+                                    )
+                                    if len(source_component_names) > 1:
+                                        source_component_name = f"[red]{source_component_names[0]} and {len(source_component_names) - 1} more[/red]"  # noqa
+                                    console.print(
+                                        Text(ps, style=f"{product_color} b u"),
+                                        source_component_name,
+                                        dep,
+                                        f"[grey]{related_url}[/grey]",
+                                        f"[grey]{build_source_url}[/grey]",
+                                        no_wrap=no_wrap,
+                                    )
+                            if not (result_tree[pv][ps][cn][nvr]["upstreams"]) and not (
+                                result_tree[pv][ps][cn][nvr]["sources"]
+                            ):
+                                child_dep_names = ""
+                                if provides_components:
+                                    try:
+                                        child_dep_names = highlight_search_term(
+                                            search_component_name,
+                                            ", ".join(provides_components),
+                                        )
+                                        child_dep_names = f"[{child_dep_names}]"
+                                    except re.error:
+                                        pass
+
+                                console.print(
+                                    Text(ps, style=f"{product_color} b"),
+                                    dep,
+                                    child_dep_names,
+                                    f"[i][grey]{related_url}[/grey][/i]",
+                                    f"[i][grey]{build_source_url}[/grey][/i]",
+                                    width=10000,
+                                    no_wrap=no_wrap,
+                                )
 
         ctx.exit()
 

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -414,7 +414,6 @@ def text_output_products_contain_component(
     exclude_components,
     no_wrap=False,
 ):
-    logger.info(ctx.obj["REGEX_NAME_SEARCH"])
     # if -r option used we need to escape it
     search_component_name = (
         re.escape(ctx.params["component_name"])

--- a/griffon/services/core_queries.py
+++ b/griffon/services/core_queries.py
@@ -199,6 +199,7 @@ class products_containing_specific_component_query:
         "include_product_stream_excluded_components",
         "output_type_filter",
         "regex_name_search",
+        "include_container_roots",
         "exclude_unreleased",
     ]
 
@@ -304,6 +305,7 @@ class products_containing_component_query:
         "include_product_stream_excluded_components",
         "output_type_filter",
         "regex_name_search",
+        "include_container_roots",
         "exclude_unreleased",
     ]
 
@@ -330,6 +332,7 @@ class products_containing_component_query:
         if not self.no_community:
             self.community_session = CommunityComponentService.create_session()
         self.include_inactive_product_streams = self.params.get("include_inactive_product_streams")
+        self.include_container_roots = self.params.get("include_container_roots")
         self.exclude_unreleased = self.params.get("exclude_unreleased")
 
     def execute(self, status=None) -> List[Dict[str, Any]]:
@@ -356,6 +359,8 @@ class products_containing_component_query:
                 search_latest_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_latest_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_latest_params["type"] = "RPM"
             search_latest_params["root_components"] = "True"
             search_latest_params["latest_components_by_streams"] = "True"
             status.update("searching latest root component(s).")
@@ -407,6 +412,9 @@ class products_containing_component_query:
                 search_provides_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_provides_params["released_components"] = "True"
+            if not self.include_container_roots:
+                logger.info("search only RPM")
+                search_provides_params["type"] = "RPM"
             search_provides_params["latest_components_by_streams"] = "True"
             status.update("searching latest provided child component(s).")
             latest_components_cnt = self.corgi_session.components.count(**search_provides_params)
@@ -460,6 +468,8 @@ class products_containing_component_query:
                 search_upstreams_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_upstreams_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_upstreams_params["type"] = "RPM"
             search_upstreams_params["latest_components_by_streams"] = "True"
             status.update("searching latest upstreams child component(s).")
             latest_components_cnt = self.corgi_session.components.count(**search_upstreams_params)
@@ -511,6 +521,8 @@ class products_containing_component_query:
                 search_related_url_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_related_url_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_related_url_params["type"] = "RPM"
             search_related_url_params["released_components"] = "True"
             related_url_components_cnt = self.corgi_session.components.count(
                 **search_related_url_params, max_results=10000
@@ -551,6 +563,8 @@ class products_containing_component_query:
                 search_all_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_all_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_all_params["type"] = "RPM"
             all_components_cnt = self.corgi_session.components.count(**search_all_params)
             status.update(f"found {all_components_cnt} all component(s).")
             # TODO: remove max_results
@@ -590,6 +604,8 @@ class products_containing_component_query:
                 search_all_roots_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_all_roots_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_all_roots_params["type"] = "RPM"
             all_src_components_cnt = self.corgi_session.components.count(**search_all_roots_params)
             status.update(f"found {all_src_components_cnt} all root component(s).")
             all_src_components = self.corgi_session.components.retrieve_list_iterator_async(
@@ -625,6 +641,8 @@ class products_containing_component_query:
                 search_all_upstreams_params["active_streams"] = "True"
             if self.exclude_unreleased:
                 search_all_upstreams_params["released_components"] = "True"
+            if not self.include_container_roots:
+                search_all_upstreams_params["type"] = "RPM"
             upstream_components_cnt = self.corgi_session.components.count(
                 **search_all_upstreams_params
             )

--- a/griffon/services/core_queries.py
+++ b/griffon/services/core_queries.py
@@ -413,7 +413,6 @@ class products_containing_component_query:
             if self.exclude_unreleased:
                 search_provides_params["released_components"] = "True"
             if not self.include_container_roots:
-                logger.info("search only RPM")
                 search_provides_params["type"] = "RPM"
             search_provides_params["latest_components_by_streams"] = "True"
             status.update("searching latest provided child component(s).")


### PR DESCRIPTION
More efficient if we filter on the query (instead of the output) when invoking --include-container-roots

