### PR TITLE
GRIF-221: Fix output when using middleware CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+* fixed searches with middleware CLI enabled (GRIF-221)
+
 
 ## [0.5.3] - 2024-01-22
 ### Fixed
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * --include-root-containers filters on the query (not the output)
 
 ### Added
- * --filter-rh-naming default value can be set via .griffonrc 
+ * --filter-rh-naming default value can be set via .griffonrc
    in default section(GRIG-121)
 
 

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -436,6 +436,7 @@ def get_product_contain_component(
     # TODO: interim hack for middleware
     if component_name and MIDDLEWARE_CLI and not no_middleware:
         operation_status.update("searching deptopia middleware.")
+        ctx.obj["MIDDLEWARE_CLI"] = MIDDLEWARE_CLI
 
         # Use split for users who runs middleware via python
         mw_command = [
@@ -489,7 +490,9 @@ def get_product_contain_component(
                                 {
                                     "name": dep.get("name"),
                                     "nvr": dep.get("nvr"),
-                                    "type": dep.get("type"),
+                                    "type": dep.get("ecosystem"),
+                                    "version": dep.get("version"),
+                                    "arch": dep.get("arch"),
                                 }
                             )
                             component["sources"] = components

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -53,7 +53,10 @@ def raw_json_transform(data, show_count: bool) -> dict:
         for item in data:
             transformed = item if type(item) is dict else item.to_dict()
             for related_data in ("upstreams", "sources", "provides"):
-                transformed[related_data] = raw_json_transform_related(transformed, related_data)
+                if related_data in transformed:
+                    transformed[related_data] = raw_json_transform_related(
+                        transformed, related_data
+                    )
             results.append(transformed)
         output = {
             "results": results,
@@ -62,8 +65,9 @@ def raw_json_transform(data, show_count: bool) -> dict:
             output["count"] = len(results)  # type: ignore
     else:
         output = data if type(data) is dict else data.to_dict()
-        for related_data in ("upstreams", "sources"):
-            output[related_data] = raw_json_transform_related(output, related_data)
+        for related_data in ("upstreams", "sources", "provides"):
+            if related_data in output:
+                output[related_data] = raw_json_transform_related(output, related_data)
     return output
 
 
@@ -429,7 +433,6 @@ def text_output_products_contain_component(
     exclude_components,
     no_wrap=False,
 ):
-
     # handle single component
     if ctx.params["purl"]:
         ordered_results = sorted(output["results"], key=lambda d: d["ofuri"])

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -810,8 +810,18 @@ def text_output_products_contain_component(
                                     width=10000,
                                     no_wrap=no_wrap,
                                 )
+
+            # TODO: this is a hack how to fallback to level 3 verbosity
+            # when using middleware CLI which does not have PURL stuff,
+            # delete once we stop using middleware CLI completely
+            middleware_cli_purl_verbose_level = (
+                ctx.obj["VERBOSE"] > 3
+                and ctx.obj["MIDDLEWARE_CLI"]
+                and not ctx.params["no_middleware"]
+            )
+
             if (
-                ctx.obj["VERBOSE"] == 3
+                ctx.obj["VERBOSE"] == 3 or middleware_cli_purl_verbose_level
             ):  # product_stream X root component nvr (type:arch) x child components [ nvr (type:arch)] x related_url x build_source_url # noqa
                 for pv in result_tree.keys():
                     for ps in result_tree[pv].keys():
@@ -926,7 +936,7 @@ def text_output_products_contain_component(
                                     no_wrap=no_wrap,
                                 )
             if (
-                ctx.obj["VERBOSE"] > 3
+                ctx.obj["VERBOSE"] > 3 and not middleware_cli_purl_verbose_level
             ):  # product_stream X root component purl x child components [ purl ] x related_url x build_source_url # noqa
                 for pv in result_tree.keys():
                     for ps in result_tree[pv].keys():


### PR DESCRIPTION
This PR:
* fixes a minor transform issue which added empty lists of related data even when these related data were not present
* fixes searches with middleware CLI as this got broken in [version 0.5.0](https://github.com/RedHatProductSecurity/griffon/releases/tag/0.5.0)