### PR TITLE
Result deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+* added --deduplicate/--no-deduplicate (enabled by default) flag on products-contain-component
+  which performs additional deduplications (all deduplication steps are listed in the --help)
+* added rhel-br/rhel deduplication (GRIF-150)
+
 ### Changed
 * change verbosity level 0 to return component name on service products-contain-component
+* verbosity level 0 (without -v option) now deduplicates multiple same components
+  per product version
+
+### Fixed
+* fixed picking the latest NVR with natural sort instead of normal sort
+* fixed listing product streams sorted naturally
+* fixed error when using -vvvv (verbosity level 4) without
+  GRIFFON_MIDDLEWARE_CLI set
 
 ## [0.5.5] - 2024-02-02
 ### Changed

--- a/griffon/commands/queries.py
+++ b/griffon/commands/queries.py
@@ -5,6 +5,7 @@
     these operations beyond cli
 
 """
+
 import copy
 import logging
 import re
@@ -363,6 +364,15 @@ def retrieve_component_summary(ctx, component_name, strict_name_search):
     default=get_config_option("default", "exclude_unreleased", False),
     help="Exclude unreleased components.",
 )
+@click.option(
+    "--deduplicate/--no-deduplicate",
+    "deduplicate",
+    default=get_config_option("default", "deduplicate", True),
+    help=(
+        "Deduplicate / do not deduplicate results "
+        "based on following rules: rhel/rhel-br redundancy"
+    ),
+)
 @click.pass_context
 @progress_bar(is_updatable=True)
 def get_product_contain_component(
@@ -396,6 +406,7 @@ def get_product_contain_component(
     regex_name_search,
     include_container_roots,
     exclude_unreleased,
+    deduplicate,
 ):
     # with console_status(ctx) as operation_status:
     """List products of a latest component."""
@@ -419,6 +430,7 @@ def get_product_contain_component(
     params.pop("sfm2_flaw_id")
     params.pop("flaw_mode")
     params.pop("affect_mode")
+    params.pop("deduplicate")
     if component_name:
         q = query_service.invoke(
             core_queries.products_containing_component_query, params, status=operation_status

--- a/griffon/helpers.py
+++ b/griffon/helpers.py
@@ -1,7 +1,9 @@
 """
 Helpers for direct usage or debbuging
 """
+
 import json
+import re
 from enum import Enum
 from typing import Callable, Optional, Type, Union
 
@@ -106,3 +108,9 @@ class Style(Enum):
 
     def __str__(self):
         return str(self.value)
+
+
+def natural_sort_key(string):
+    """Key for builtin sorted function to perform natural sort"""
+    split_by_digit = re.split("([0-9]+)", string)
+    return [int(part) if part.isdigit() else part.lower() for part in split_by_digit]

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -17,6 +17,8 @@ from rich.console import Console
 from rich.text import Text
 from rich.tree import Tree
 
+from .helpers import natural_sort_key
+
 console = Console(color_system="auto")
 
 logger = logging.getLogger("griffon")
@@ -511,7 +513,9 @@ def text_output_products_contain_component(
                     for ps in result_tree[pv].keys():
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
-                            nvr = list(result_tree[pv][ps][cn].keys())[-1]
+                            nvr = sorted(
+                                list(result_tree[pv][ps][cn].keys()), key=natural_sort_key
+                            )[-1]
                             product_color = process_product_color(
                                 result_tree[pv][ps][cn][nvr]["product_stream_relations"],
                                 result_tree[pv][ps][cn][nvr]["build_type"],
@@ -579,7 +583,9 @@ def text_output_products_contain_component(
                     for ps in result_tree[pv].keys():
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
-                            nvr = list(result_tree[pv][ps][cn].keys())[-1]
+                            nvr = sorted(
+                                list(result_tree[pv][ps][cn].keys()), key=natural_sort_key
+                            )[-1]
                             product_color = process_product_color(
                                 result_tree[pv][ps][cn][nvr]["product_stream_relations"],
                                 result_tree[pv][ps][cn][nvr]["build_type"],
@@ -703,7 +709,9 @@ def text_output_products_contain_component(
                     for ps in result_tree[pv].keys():
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
-                            nvr = list(result_tree[pv][ps][cn].keys())[-1]
+                            nvr = sorted(
+                                list(result_tree[pv][ps][cn].keys()), key=natural_sort_key
+                            )[-1]
                             product_color = process_product_color(
                                 result_tree[pv][ps][cn][nvr]["product_stream_relations"],
                                 result_tree[pv][ps][cn][nvr]["build_type"],
@@ -856,7 +864,9 @@ def text_output_products_contain_component(
                     for ps in result_tree[pv].keys():
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
-                            nvr = list(result_tree[pv][ps][cn].keys())[-1]
+                            nvr = sorted(
+                                list(result_tree[pv][ps][cn].keys()), key=natural_sort_key
+                            )[-1]
                             product_color = process_product_color(
                                 result_tree[pv][ps][cn][nvr]["product_stream_relations"],
                                 result_tree[pv][ps][cn][nvr]["build_type"],
@@ -971,7 +981,9 @@ def text_output_products_contain_component(
                     for ps in result_tree[pv].keys():
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
-                            nvr = list(result_tree[pv][ps][cn].keys())[-1]
+                            nvr = sorted(
+                                list(result_tree[pv][ps][cn].keys()), key=natural_sort_key
+                            )[-1]
                             product_color = process_product_color(
                                 result_tree[pv][ps][cn][nvr]["product_stream_relations"],
                                 result_tree[pv][ps][cn][nvr]["build_type"],

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -510,7 +510,7 @@ def text_output_products_contain_component(
             if ctx.obj["VERBOSE"] == 0:  # product_version X root component nvr
                 for pv in result_tree.keys():
                     used_component_names = set()  # store used component names for deduplication
-                    for ps in result_tree[pv].keys():
+                    for ps in sorted(result_tree[pv].keys(), key=natural_sort_key):
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = sorted(
@@ -602,7 +602,7 @@ def text_output_products_contain_component(
                 ctx.obj["VERBOSE"] == 1
             ):  # product_stream X root component nvr (type) x child components [nvr (type)]
                 for pv in result_tree.keys():
-                    for ps in result_tree[pv].keys():
+                    for ps in sorted(result_tree[pv].keys(), key=natural_sort_key):
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = sorted(
@@ -728,7 +728,7 @@ def text_output_products_contain_component(
                 ctx.obj["VERBOSE"] == 2
             ):  # product_stream X root component nvr (type:arch) x child components [name {versions} (type:{arches})] x related_url x build_source_url # noqa
                 for pv in result_tree.keys():
-                    for ps in result_tree[pv].keys():
+                    for ps in sorted(result_tree[pv].keys(), key=natural_sort_key):
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = sorted(
@@ -883,7 +883,7 @@ def text_output_products_contain_component(
                 ctx.obj["VERBOSE"] == 3 or middleware_cli_purl_verbose_level
             ):  # product_stream X root component nvr (type:arch) x child components [ nvr (type:arch)] x related_url x build_source_url # noqa
                 for pv in result_tree.keys():
-                    for ps in result_tree[pv].keys():
+                    for ps in sorted(result_tree[pv].keys(), key=natural_sort_key):
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = sorted(
@@ -1000,7 +1000,7 @@ def text_output_products_contain_component(
                 ctx.obj["VERBOSE"] > 3 and not middleware_cli_purl_verbose_level
             ):  # product_stream X root component purl x child components [ purl ] x related_url x build_source_url # noqa
                 for pv in result_tree.keys():
-                    for ps in result_tree[pv].keys():
+                    for ps in sorted(result_tree[pv].keys(), key=natural_sort_key):
                         for cn in sorted(result_tree[pv][ps].keys()):
                             # select the latest nvr (from sorted list)
                             nvr = sorted(

--- a/griffon/output.py
+++ b/griffon/output.py
@@ -853,7 +853,7 @@ def text_output_products_contain_component(
             # delete once we stop using middleware CLI completely
             middleware_cli_purl_verbose_level = (
                 ctx.obj["VERBOSE"] > 3
-                and ctx.obj["MIDDLEWARE_CLI"]
+                and ctx.obj.get("MIDDLEWARE_CLI")
                 and not ctx.params["no_middleware"]
             )
 

--- a/griffon/static/default_griffonrc
+++ b/griffon/static/default_griffonrc
@@ -17,12 +17,13 @@ exclude_components = -container-source
     -common-debuginfo
     -doc
     -devel
-    -javadoc 
-    -testlib 
+    -javadoc
+    -testlib
     -repolib
 include_container_roots = False
 exclude_unreleased = False
 filter_rh_naming = True
+deduplicate = True
 
 # profile sections (use with --profile {profile} flag)
 [cloud]


### PR DESCRIPTION
This PR:
* adds the `--deduplicate/--no-deduplicate` options for products-contain-component
* adds rhel/rhel-br deduplication step (GRIF-150)
* deduplicates results on verbosity level 0
* minor fixes - `-vvvv` with no  `GRIFFON_MIDDLEWARE_CLI` fix, latest NVR pick fix, naturally sorted product streams fix